### PR TITLE
Fix cycles causing stack overflows

### DIFF
--- a/src/main/java/com/deepoove/swagger/diff/compare/ModelDiff.java
+++ b/src/main/java/com/deepoove/swagger/diff/compare/ModelDiff.java
@@ -1,12 +1,16 @@
 package com.deepoove.swagger.diff.compare;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 
 import com.deepoove.swagger.diff.model.ElProperty;
+import com.google.common.collect.ImmutableMap;
 
 import io.swagger.models.Model;
 import io.swagger.models.properties.Property;
@@ -21,6 +25,8 @@ public class ModelDiff {
 
 	private List<ElProperty> increased;
 	private List<ElProperty> missing;
+	private List<ElProperty> changed;
+	private int count = 0;
 
 	Map<String, Model> oldDedinitions;
 	Map<String, Model> newDedinitions;
@@ -28,6 +34,7 @@ public class ModelDiff {
 	private ModelDiff() {
 		increased = new ArrayList<ElProperty>();
 		missing = new ArrayList<ElProperty>();
+		changed = new ArrayList<ElProperty>();
 	}
 
 	public static ModelDiff buildWithDefinition(Map<String, Model> left,
@@ -39,38 +46,52 @@ public class ModelDiff {
 	}
 
 	public ModelDiff diff(Model leftModel, Model rightModel) {
-		return this.diff(leftModel, rightModel, null);
+		return this.diff(leftModel, rightModel, null, new HashSet<String>());
 	}
 
 	public ModelDiff diff(Model leftModel, Model rightModel, String parentEl) {
-		if (null == leftModel && null == rightModel) return this;
+		return this.diff(leftModel, rightModel, parentEl, new HashSet<String>());
+	}
+
+	private ModelDiff diff(Model leftModel, Model rightModel, String parentEl, Set<String> visited) {
+		if ((null == leftModel && null == rightModel)) return this;
 		Map<String, Property> leftProperties = null == leftModel ? null : leftModel.getProperties();
 		Map<String, Property> rightProperties = null == rightModel ? null : rightModel.getProperties();
 		MapKeyDiff<String, Property> propertyDiff = MapKeyDiff.diff(leftProperties, rightProperties);
 		Map<String, Property> increasedProp = propertyDiff.getIncreased();
 		Map<String, Property> missingProp = propertyDiff.getMissing();
 
-		increased.addAll(convert2ElPropertys(increasedProp, parentEl, false));
-		missing.addAll(convert2ElPropertys(missingProp, parentEl, true));
+		increased.addAll(asElProperties(increasedProp, parentEl, false, new HashSet<String>()));
+		missing.addAll(asElProperties(missingProp, parentEl, true, new HashSet<String>()));
 
 		List<String> sharedKey = propertyDiff.getSharedKey();
 		for (String key : sharedKey) {
 			Property left = leftProperties.get(key);
 			Property right = rightProperties.get(key);
-			if (left instanceof RefProperty
-					&& right instanceof RefProperty) {
+
+			if (RefProperty.class.isInstance(left) && RefProperty.class.isInstance(right)) {
 				String leftRef = ((RefProperty) left).getSimpleRef();
 				String rightRef = ((RefProperty) right).getSimpleRef();
-				diff(oldDedinitions.get(leftRef),
-						newDedinitions.get(rightRef),
-						null == parentEl ? key : (parentEl + "." + key));
+
+				if (!visited.contains(leftRef) && !visited.contains(rightRef)) {
+					count += 1;
+					diff(oldDedinitions.get(leftRef), newDedinitions.get(rightRef),
+							null == parentEl ? key : (parentEl + "." + key),
+							copyAndAdd(visited, leftRef, rightRef));
+				}
+			} else if (!left.equals(right)) {
+				changed.add(asElProperty(key, left, parentEl));
 			}
 		}
 		return this;
 	}
 
-	private Collection<? extends ElProperty> convert2ElPropertys(
-			Map<String, Property> propMap, String parentEl, boolean isLeft) {
+	private ElProperty asElProperty(String propName, Property prop, String parentEl) {
+		return new ArrayList<ElProperty>(asElProperties(ImmutableMap.of(propName, prop), parentEl, true, new HashSet<String>())).get(0);
+	}
+
+	private Collection<? extends ElProperty> asElProperties(
+			Map<String, Property> propMap, String parentEl, boolean isLeft, Set<String> visited) {
 		List<ElProperty> result = new ArrayList<ElProperty>();
 		if (null == propMap) return result;
 		for (Entry<String, Property> entry : propMap.entrySet()) {
@@ -80,23 +101,33 @@ public class ModelDiff {
 				String ref = ((RefProperty) property).getSimpleRef();
 				Model model = isLeft ? oldDedinitions.get(ref)
 						: newDedinitions.get(ref);
-				if (model != null) {
+				if (model != null && !visited.contains(ref)) {
 					Map<String, Property> properties = model.getProperties();
 					result.addAll(
-							convert2ElPropertys(properties,
+							asElProperties(properties,
 									null == parentEl ? propName
 											: (parentEl + "." + propName),
-									isLeft));
+									isLeft, copyAndAdd(visited, ref)));
+					return result;
 				}
-			} else {
-				ElProperty pWithPath = new ElProperty();
-				pWithPath.setProperty(property);
-				pWithPath.setEl(null == parentEl ? propName
-						: (parentEl + "." + propName));
-				result.add(pWithPath);
 			}
+			result.add(buildElProperty(propName, parentEl, property));
 		}
 		return result;
+	}
+
+	private ElProperty buildElProperty(String propName, String parentEl, Property property) {
+		ElProperty pWithPath = new ElProperty();
+		pWithPath.setProperty(property);
+		pWithPath.setEl(null == parentEl ? propName
+				: (parentEl + "." + propName));
+		return pWithPath;
+	}
+
+	private <T> Set<T> copyAndAdd(Set<T> set, T... add) {
+		Set<T> newSet = new HashSet<T>(set);
+		newSet.addAll(Arrays.asList(add));
+		return newSet;
 	}
 
 	public List<ElProperty> getIncreased() {
@@ -115,4 +146,11 @@ public class ModelDiff {
 		this.missing = missing;
 	}
 
+	public List<ElProperty> getChanged() {
+		return changed;
+	}
+
+	public void setChanged(List<ElProperty> changed) {
+		this.changed = changed;
+	}
 }

--- a/src/main/java/com/deepoove/swagger/diff/compare/ParameterDiff.java
+++ b/src/main/java/com/deepoove/swagger/diff/compare/ParameterDiff.java
@@ -72,6 +72,7 @@ public class ParameterDiff {
 						ModelDiff diff = ModelDiff.buildWithDefinition(oldDedinitions, newDedinitions).diff(leftModel, rightModel, name);
 						changedParameter.setIncreased(diff.getIncreased());
 						changedParameter.setMissing(diff.getMissing());
+						changedParameter.setChanged(diff.getChanged());
 					}
 				}
 				

--- a/src/main/java/com/deepoove/swagger/diff/compare/PropertyDiff.java
+++ b/src/main/java/com/deepoove/swagger/diff/compare/PropertyDiff.java
@@ -14,6 +14,7 @@ public class PropertyDiff {
 
 	private List<ElProperty> increased;
 	private List<ElProperty> missing;
+	private List<ElProperty> changed;
 
 	Map<String, Model> oldDedinitions;
 	Map<String, Model> newDedinitions;
@@ -21,6 +22,7 @@ public class PropertyDiff {
 	private PropertyDiff() {
 		increased = new ArrayList<ElProperty>();
 		missing = new ArrayList<ElProperty>();
+		changed = new ArrayList<ElProperty>();
 	}
 
 	public static PropertyDiff buildWithDefinition(Map<String, Model> left,
@@ -40,6 +42,7 @@ public class PropertyDiff {
 					.diff(leftModel, rightModel);
 			increased.addAll(diff.getIncreased());
 			missing.addAll(diff.getMissing());
+			changed.addAll(diff.getChanged());
 		}
 		return this;
 	}
@@ -60,4 +63,11 @@ public class PropertyDiff {
 		this.missing = missing;
 	}
 
+	public List<ElProperty> getChanged() {
+		return changed;
+	}
+
+	public void setChanged(List<ElProperty> changed) {
+		this.changed = changed;
+	}
 }

--- a/src/main/java/com/deepoove/swagger/diff/compare/SpecificationDiff.java
+++ b/src/main/java/com/deepoove/swagger/diff/compare/SpecificationDiff.java
@@ -87,6 +87,7 @@ public class SpecificationDiff {
 				propertyDiff.diff(oldResponseProperty, newResponseProperty);
 				changedOperation.setAddProps(propertyDiff.getIncreased());
 				changedOperation.setMissingProps(propertyDiff.getMissing());
+				changedOperation.setChangedProps(propertyDiff.getChanged());
 
 				if (changedOperation.isDiff()) {
 					operas.put(method, changedOperation);

--- a/src/main/java/com/deepoove/swagger/diff/model/ChangedOperation.java
+++ b/src/main/java/com/deepoove/swagger/diff/model/ChangedOperation.java
@@ -16,6 +16,7 @@ public class ChangedOperation implements Changed {
 
 	private List<ElProperty> addProps = new ArrayList<ElProperty>();
 	private List<ElProperty> missingProps = new ArrayList<ElProperty>();
+	private List<ElProperty> changedProps = new ArrayList<ElProperty>();
 
 	public List<Parameter> getAddParameters() {
 		return addParameters;
@@ -57,6 +58,14 @@ public class ChangedOperation implements Changed {
 		this.missingProps = missingProps;
 	}
 
+	public List<ElProperty> getChangedProps() {
+		return changedProps;
+	}
+
+	public void setChangedProps(List<ElProperty> changedProps) {
+		this.changedProps = changedProps;
+	}
+
 	public String getSummary() {
 		return summary;
 	}
@@ -67,16 +76,15 @@ public class ChangedOperation implements Changed {
 
 	public boolean isDiff() {
 		return !addParameters.isEmpty() || !missingParameters.isEmpty()
-				|| !changedParameter.isEmpty() || !addProps.isEmpty()
-				|| !missingProps.isEmpty();
+				|| !changedParameter.isEmpty() || isDiffProp();
 	}
 	public boolean isDiffProp(){
 		return !addProps.isEmpty()
-				|| !missingProps.isEmpty();
+				|| !missingProps.isEmpty()
+				|| !changedProps.isEmpty();
 	}
 	public boolean isDiffParam(){
 		return !addParameters.isEmpty() || !missingParameters.isEmpty()
 				|| !changedParameter.isEmpty();
 	}
-
 }

--- a/src/main/java/com/deepoove/swagger/diff/model/ChangedParameter.java
+++ b/src/main/java/com/deepoove/swagger/diff/model/ChangedParameter.java
@@ -8,7 +8,8 @@ import io.swagger.models.parameters.Parameter;
 public class ChangedParameter implements Changed {
 	
 	private List<ElProperty> increased = new ArrayList<ElProperty>();
-	private List<ElProperty> missing = new ArrayList<ElProperty>();;
+	private List<ElProperty> missing = new ArrayList<ElProperty>();
+	private List<ElProperty> changed = new ArrayList<ElProperty>();
 
 	private Parameter leftParameter;
 	private Parameter rightParameter;
@@ -50,7 +51,11 @@ public class ChangedParameter implements Changed {
 	}
 
 	public boolean isDiff() {
-		return isChangeRequired || isChangeDescription || !increased.isEmpty() || !missing.isEmpty();
+		return isChangeRequired
+				|| isChangeDescription
+				|| !increased.isEmpty()
+				|| !missing.isEmpty()
+				|| !changed.isEmpty();
 	}
 
 	public List<ElProperty> getIncreased() {
@@ -68,6 +73,12 @@ public class ChangedParameter implements Changed {
 	public void setMissing(List<ElProperty> missing) {
 		this.missing = missing;
 	}
-	
 
+	public List<ElProperty> getChanged() {
+		return changed;
+	}
+
+	public void setChanged(List<ElProperty> changed) {
+		this.changed = changed;
+	}
 }

--- a/src/main/java/com/deepoove/swagger/diff/output/MarkdownRender.java
+++ b/src/main/java/com/deepoove/swagger/diff/output/MarkdownRender.java
@@ -103,7 +103,7 @@ public class MarkdownRender implements Render {
 					ul_detail.append(PRE_LI).append("Return Type")
 							.append(ul_response(changedOperation));
 				}
-				sb.append(LI).append(CODE).append(method).append(CODE)
+				sb.append(CODE).append(method).append(CODE)
 						.append(" " + pathUrl).append(" " + desc + "  \n")
 						.append(ul_detail);
 			}
@@ -117,7 +117,7 @@ public class MarkdownRender implements Render {
 		List<ElProperty> changedProps = changedOperation.getChangedProps();
 		StringBuffer sb = new StringBuffer("\n");
 
-		String prefix = PRE_LI + PRE_CODE + LI;
+		String prefix = PRE_LI + PRE_CODE;
 		for (ElProperty prop : addProps) {
 			sb.append(PRE_LI).append(PRE_CODE).append(li_addProp(prop) + "\n");
 		}

--- a/src/main/java/com/deepoove/swagger/diff/output/MarkdownRender.java
+++ b/src/main/java/com/deepoove/swagger/diff/output/MarkdownRender.java
@@ -114,13 +114,18 @@ public class MarkdownRender implements Render {
 	private String ul_response(ChangedOperation changedOperation) {
 		List<ElProperty> addProps = changedOperation.getAddProps();
 		List<ElProperty> delProps = changedOperation.getMissingProps();
-		StringBuffer sb = new StringBuffer("\n\n");
+		List<ElProperty> changedProps = changedOperation.getChangedProps();
+		StringBuffer sb = new StringBuffer("\n");
+
+		String prefix = PRE_LI + PRE_CODE + LI;
 		for (ElProperty prop : addProps) {
 			sb.append(PRE_LI).append(PRE_CODE).append(li_addProp(prop) + "\n");
 		}
 		for (ElProperty prop : delProps) {
-			sb.append(PRE_LI).append(PRE_CODE)
-					.append(li_missingProp(prop) + "\n");
+			sb.append(prefix).append(li_missingProp(prop) + "\n");
+		}
+		for (ElProperty prop : changedProps) {
+			sb.append(prefix).append(li_changedProp(prop) + "\n");
 		}
 		return sb.toString();
 	}
@@ -140,6 +145,19 @@ public class MarkdownRender implements Render {
 		sb.append("Add ").append(prop.getEl())
 				.append(null == property.getDescription() ? ""
 						: (" //" + property.getDescription()));
+		return sb.toString();
+	}
+
+	private String li_changedProp(ElProperty prop) {
+		Property property = prop.getProperty();
+		String prefix = "Modified " + CODE;
+		String desc = " //" + property.getDescription();
+		String postfix = CODE +
+				(null == property.getDescription() ? "" : desc);
+
+		StringBuffer sb = new StringBuffer("");
+		sb.append(prefix).append(prop.getEl())
+				.append(postfix);
 		return sb.toString();
 	}
 
@@ -168,9 +186,13 @@ public class MarkdownRender implements Render {
 		}
 		for (ChangedParameter param : changedParameters) {
 			List<ElProperty> missing = param.getMissing();
+			List<ElProperty> changed = param.getChanged();
 			for (ElProperty prop : missing) {
 				sb.append(PRE_LI).append(PRE_CODE)
 						.append(li_missingProp(prop) + "\n");
+			}
+			for (ElProperty prop : changed) {
+				sb.append(li_changedProp(prop) + "\n");
 			}
 		}
 		for (Parameter param : delParameters) {

--- a/src/test/resources/petstore_v2_1.json
+++ b/src/test/resources/petstore_v2_1.json
@@ -894,6 +894,9 @@
         "phone": {
           "type": "string"
         },
+        "favorite": {
+          "$ref": "#/definitions/Pet"
+        },
         "userStatus": {
           "type": "integer",
           "format": "int32",
@@ -946,6 +949,9 @@
           "items": {
             "type": "string"
           }
+        },
+        "owner": {
+          "$ref": "#/definitions/User"
         },
         "parent": {
           "$ref": "#/definitions/Pet"

--- a/src/test/resources/petstore_v2_1.json
+++ b/src/test/resources/petstore_v2_1.json
@@ -947,6 +947,9 @@
             "type": "string"
           }
         },
+        "parent": {
+          "$ref": "#/definitions/Pet"
+        },
         "tags": {
           "type": "array",
           "xml": {

--- a/src/test/resources/petstore_v2_2.json
+++ b/src/test/resources/petstore_v2_2.json
@@ -890,6 +890,9 @@
         "password": {
           "type": "string"
         },
+        "favorite": {
+          "$ref": "#/definitions/Pet"
+        },
         "userStatus": {
           "type": "integer",
           "format": "int32",
@@ -942,6 +945,9 @@
           "type": "string",
           "example": "a feild demo by sayi",
           "description": "a feild demo by sayi"
+        },
+        "owner": {
+          "$ref": "#/definitions/User"
         },
         "parent": {
           "$ref": "#/definitions/Pet"

--- a/src/test/resources/petstore_v2_2.json
+++ b/src/test/resources/petstore_v2_2.json
@@ -943,6 +943,9 @@
           "example": "a feild demo by sayi",
           "description": "a feild demo by sayi"
         },
+        "parent": {
+          "$ref": "#/definitions/Pet"
+        },
         "photoUrls": {
           "type": "array",
           "xml": {


### PR DESCRIPTION
Fixes the bug where cyclical references in the definitions of models would cause stack overflows as both `ModelDiff#diff` and `ModelDiff#convert2ElPropertys` would recurse infinitely through the cycle.

This is now mitigated by passing a set containing the models that have already been "visited" in the current branch of the recursion tree. If a model has already been visited, the method will short circuit, and prevent any further traversal of the cycle.

To test that the stack overflows are fixed, I added several cyclical references to the test swagger documents:

1. `Pet.parent` references `#/definitions/Pet` (a self-reference cycle)
2. The `Pet.owner` references `#/definitions/User`, and `User.favorite` references `#/definitions/Pet`, creating a cycle between the two.

All tests as written still pass, and upon examination of the swagger, you can see that there are fields from `User` showing up in the changes to `Pet`s and vice versa, eg:

### What's Changed
---
`POST` /pet Add a new pet to the store  
    Parameter

        Add tags //add new query param demo
        Add body.newFeild //a feild demo by sayi
        Add body.category.newCatFeild
        Add body.owner.newUserFeild //a new user feild demo
        Delete body.category.name
        Delete body.owner.phone