### PR TITLE
Add vendor extensions

### DIFF
--- a/src/main/java/com/deepoove/swagger/diff/SwaggerDiff.java
+++ b/src/main/java/com/deepoove/swagger/diff/SwaggerDiff.java
@@ -2,12 +2,14 @@ package com.deepoove.swagger.diff;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.deepoove.swagger.diff.compare.SpecificationDiff;
 import com.deepoove.swagger.diff.model.ChangedEndpoint;
+import com.deepoove.swagger.diff.model.ChangedVendorExtensionGroup;
 import com.deepoove.swagger.diff.model.Endpoint;
 import com.fasterxml.jackson.databind.JsonNode;
 
@@ -28,6 +30,8 @@ public class SwaggerDiff {
     private List<Endpoint> newEndpoints;
     private List<Endpoint> missingEndpoints;
     private List<ChangedEndpoint> changedEndpoints;
+
+    private ChangedVendorExtensionGroup changedTopLevelVendorExtensions;
 
     /**
      * compare two swagger 1.x doc
@@ -109,6 +113,7 @@ public class SwaggerDiff {
         this.newEndpoints = diff.getNewEndpoints();
         this.missingEndpoints = diff.getMissingEndpoints();
         this.changedEndpoints = diff.getChangedEndpoints();
+        this.changedTopLevelVendorExtensions = diff.getNonPathVendorExtGroup();
         return this;
     }
 
@@ -122,6 +127,10 @@ public class SwaggerDiff {
 
     public List<ChangedEndpoint> getChangedEndpoints() {
         return changedEndpoints;
+    }
+
+    public ChangedVendorExtensionGroup getChangedTopLevelVendorExtensions() {
+        return changedTopLevelVendorExtensions;
     }
 
     public String getOldVersion() {

--- a/src/main/java/com/deepoove/swagger/diff/SwaggerDiff.java
+++ b/src/main/java/com/deepoove/swagger/diff/SwaggerDiff.java
@@ -2,14 +2,13 @@ package com.deepoove.swagger.diff;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Map;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.deepoove.swagger.diff.compare.SpecificationDiff;
 import com.deepoove.swagger.diff.model.ChangedEndpoint;
-import com.deepoove.swagger.diff.model.ChangedVendorExtensionGroup;
+import com.deepoove.swagger.diff.model.ChangedExtensionGroup;
 import com.deepoove.swagger.diff.model.Endpoint;
 import com.fasterxml.jackson.databind.JsonNode;
 
@@ -31,7 +30,7 @@ public class SwaggerDiff {
     private List<Endpoint> missingEndpoints;
     private List<ChangedEndpoint> changedEndpoints;
 
-    private ChangedVendorExtensionGroup changedTopLevelVendorExtensions;
+    private ChangedExtensionGroup changedTopLevelVendorExtensions;
 
     /**
      * compare two swagger 1.x doc
@@ -129,7 +128,7 @@ public class SwaggerDiff {
         return changedEndpoints;
     }
 
-    public ChangedVendorExtensionGroup getChangedTopLevelVendorExtensions() {
+    public ChangedExtensionGroup getChangedTopLevelVendorExtensions() {
         return changedTopLevelVendorExtensions;
     }
 

--- a/src/main/java/com/deepoove/swagger/diff/SwaggerDiff.java
+++ b/src/main/java/com/deepoove/swagger/diff/SwaggerDiff.java
@@ -30,7 +30,7 @@ public class SwaggerDiff {
     private List<Endpoint> missingEndpoints;
     private List<ChangedEndpoint> changedEndpoints;
 
-    private ChangedExtensionGroup changedTopLevelVendorExtensions;
+    private ChangedExtensionGroup changedVendorExtensions;
 
     /**
      * compare two swagger 1.x doc
@@ -41,7 +41,7 @@ public class SwaggerDiff {
      *            new api-doc location:Json or Http
      */
     public static SwaggerDiff compareV1(String oldSpec, String newSpec) {
-        return compareV1(oldSpec, oldSpec, false);
+        return compareV1(oldSpec, newSpec, false);
     }
 
     public static SwaggerDiff compareV1(String oldSpec, String newSpec, boolean withExtensions) {
@@ -57,7 +57,7 @@ public class SwaggerDiff {
      *            new api-doc location:Json or Http
      */
     public static SwaggerDiff compareV2(String oldSpec, String newSpec) {
-        return compare(oldSpec, newSpec, null, SWAGGER_VERSION_V2, false);
+        return compareV2(oldSpec, newSpec, false);
     }
 
     public static SwaggerDiff compareV2(String oldSpec, String newSpec, boolean withExtensions) {
@@ -124,7 +124,7 @@ public class SwaggerDiff {
         this.newEndpoints = diff.getNewEndpoints();
         this.missingEndpoints = diff.getMissingEndpoints();
         this.changedEndpoints = diff.getChangedEndpoints();
-        this.changedTopLevelVendorExtensions = diff.getNonPathVendorExtGroup();
+        this.changedVendorExtensions = diff;
         return this;
     }
 
@@ -140,8 +140,8 @@ public class SwaggerDiff {
         return changedEndpoints;
     }
 
-    public ChangedExtensionGroup getChangedTopLevelVendorExtensions() {
-        return changedTopLevelVendorExtensions;
+    public ChangedExtensionGroup getChangedVendorExtensions() {
+        return changedVendorExtensions;
     }
 
     public String getOldVersion() {

--- a/src/main/java/com/deepoove/swagger/diff/SwaggerDiff.java
+++ b/src/main/java/com/deepoove/swagger/diff/SwaggerDiff.java
@@ -41,7 +41,11 @@ public class SwaggerDiff {
      *            new api-doc location:Json or Http
      */
     public static SwaggerDiff compareV1(String oldSpec, String newSpec) {
-        return compare(oldSpec, newSpec, null, null);
+        return compareV1(oldSpec, oldSpec, false);
+    }
+
+    public static SwaggerDiff compareV1(String oldSpec, String newSpec, boolean withExtensions) {
+        return compare(oldSpec, newSpec, null, null, withExtensions);
     }
 
     /**
@@ -53,7 +57,11 @@ public class SwaggerDiff {
      *            new api-doc location:Json or Http
      */
     public static SwaggerDiff compareV2(String oldSpec, String newSpec) {
-        return compare(oldSpec, newSpec, null, SWAGGER_VERSION_V2);
+        return compare(oldSpec, newSpec, null, SWAGGER_VERSION_V2, false);
+    }
+
+    public static SwaggerDiff compareV2(String oldSpec, String newSpec, boolean withExtensions) {
+        return compare(oldSpec, newSpec, null, SWAGGER_VERSION_V2, withExtensions);
     }
 
     /**
@@ -65,12 +73,16 @@ public class SwaggerDiff {
      *            new Swagger specification document in v2.0 format as a JsonNode
      */
     public static SwaggerDiff compareV2(JsonNode oldSpec, JsonNode newSpec) {
-        return new SwaggerDiff(oldSpec, newSpec).compare();
+        return compareV2(oldSpec, newSpec, false);
+    }
+
+    public static SwaggerDiff compareV2(JsonNode oldSpec, JsonNode newSpec, boolean withExtensions) {
+        return new SwaggerDiff(oldSpec, newSpec).compare(withExtensions);
     }
 
     public static SwaggerDiff compare(String oldSpec, String newSpec,
-            List<AuthorizationValue> auths, String version) {
-        return new SwaggerDiff(oldSpec, newSpec, auths, version).compare();
+            List<AuthorizationValue> auths, String version, boolean withExtensions) {
+        return new SwaggerDiff(oldSpec, newSpec, auths, version).compare(withExtensions);
     }
 
     /**
@@ -107,8 +119,8 @@ public class SwaggerDiff {
             "cannot read api-doc from spec."); }
     }
 
-    private SwaggerDiff compare() {
-    	SpecificationDiff diff = SpecificationDiff.diff(oldSpecSwagger, newSpecSwagger);
+    private SwaggerDiff compare(boolean withExtensions) {
+    	SpecificationDiff diff = SpecificationDiff.diff(oldSpecSwagger, newSpecSwagger, withExtensions);
         this.newEndpoints = diff.getNewEndpoints();
         this.missingEndpoints = diff.getMissingEndpoints();
         this.changedEndpoints = diff.getChangedEndpoints();

--- a/src/main/java/com/deepoove/swagger/diff/compare/MapDiff.java
+++ b/src/main/java/com/deepoove/swagger/diff/compare/MapDiff.java
@@ -1,0 +1,70 @@
+package com.deepoove.swagger.diff.compare;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.apache.commons.lang3.tuple.Pair;
+
+
+public class MapDiff<K, V> {
+  private Map<K, V> increased = new LinkedHashMap<K, V>();
+  private Map<K, V> missing = new LinkedHashMap<K, V>();
+  private Map<K, Pair<V, V>> changed = new LinkedHashMap<K, Pair<V, V>>();
+
+
+  private MapDiff() {
+
+  }
+
+  public static <K, V> MapDiff<K, V> diff(Map<K, V> mapLeft,
+                                          Map<K, V> mapRight) {
+    MapDiff instance = new MapDiff();
+    if (null == mapLeft && null == mapRight) return instance;
+
+    if (null == mapLeft) {
+      instance.increased = mapRight;
+      return instance;
+    }
+
+    if (null == mapRight) {
+      instance.missing = mapLeft;
+      return instance;
+    }
+
+    instance.increased.putAll(mapRight);
+
+    for (Entry<K, V> entry : mapLeft.entrySet()) {
+      K leftKey = entry.getKey();
+      V leftValue = entry.getValue();
+
+      if (mapRight.containsKey(leftKey)) {
+        instance.increased.remove(leftKey);
+
+        if (!(mapRight.get(leftKey).getClass().isInstance(leftValue) && mapRight.get(leftKey).equals(leftValue))) {
+          instance.changed.put(leftKey, Pair.of(leftValue, mapRight.get(leftKey)));
+        }
+      } else {
+        instance.missing.put(leftKey, leftValue);
+      }
+    }
+    return instance;
+  }
+
+  public Map<K, V> getIncreased() {
+    return increased;
+  }
+
+  public Map<K, V> getMissing() {
+    return missing;
+  }
+
+  public Map<K, Pair<V, V>> getChanged() {
+    return changed;
+  }
+
+  public List<K> getSharedKey() { return new ArrayList<K>(changed.keySet()); }
+}

--- a/src/main/java/com/deepoove/swagger/diff/compare/MapDiff.java
+++ b/src/main/java/com/deepoove/swagger/diff/compare/MapDiff.java
@@ -1,9 +1,6 @@
 package com.deepoove.swagger.diff.compare;
 
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
@@ -65,6 +62,4 @@ public class MapDiff<K, V> {
   public Map<K, Pair<V, V>> getChanged() {
     return changed;
   }
-
-  public List<K> getSharedKey() { return new ArrayList<K>(changed.keySet()); }
 }

--- a/src/main/java/com/deepoove/swagger/diff/compare/SpecificationDiff.java
+++ b/src/main/java/com/deepoove/swagger/diff/compare/SpecificationDiff.java
@@ -57,11 +57,17 @@ public class SpecificationDiff {
 		instance.missingEndpoints = convert2EndpointList(pathDiff.getMissing());
 		instance.changedEndpoints = new ArrayList<ChangedEndpoint>();
 
+		System.out.println(oldSpec.getVendorExtensions());
 
 		Map<String, Object> oldExts;
 		Map<String, Object> newExts;
 
 		if (withExtensions) {
+
+			oldExts = oldSpec.getVendorExtensions();
+			newExts = newSpec.getVendorExtensions();
+			instance.nonPathVendorExtGroup.setVendorExtsFromGroup(getChangedVendorExtsGroup( oldExts, newExts));
+
 			oldExts = oldSpec.getInfo().getVendorExtensions();
 			newExts = newSpec.getInfo().getVendorExtensions();
 			instance.nonPathVendorExtGroup.getChangedSubGroups()

--- a/src/main/java/com/deepoove/swagger/diff/compare/SpecificationDiff.java
+++ b/src/main/java/com/deepoove/swagger/diff/compare/SpecificationDiff.java
@@ -8,13 +8,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import org.apache.commons.lang3.tuple.Pair;
-
 import com.deepoove.swagger.diff.model.ChangedEndpoint;
 import com.deepoove.swagger.diff.model.ChangedOperation;
 import com.deepoove.swagger.diff.model.ChangedParameter;
-import com.deepoove.swagger.diff.model.ChangedVendorExtensionGroup;
-import com.deepoove.swagger.diff.model.ElProperty;
+import com.deepoove.swagger.diff.model.ChangedExtensionGroup;
 import com.deepoove.swagger.diff.model.Endpoint;
 
 import io.swagger.models.HttpMethod;
@@ -39,12 +36,16 @@ public class SpecificationDiff {
 	private List<Endpoint> missingEndpoints;
 	private List<ChangedEndpoint> changedEndpoints;
 
-	private ChangedVendorExtensionGroup nonPathVendorExtGroup = new ChangedVendorExtensionGroup();
+	private ChangedExtensionGroup nonPathVendorExtGroup = new ChangedExtensionGroup();
 
 	private SpecificationDiff() {
 	}
 
 	public static SpecificationDiff diff(Swagger oldSpec, Swagger newSpec) {
+		return diff(oldSpec, newSpec, true);
+	}
+
+	public static SpecificationDiff diff(Swagger oldSpec, Swagger newSpec, boolean withExtensions) {
 		SpecificationDiff instance = new SpecificationDiff();
 		if (null == oldSpec || null == newSpec) {
 			throw new IllegalArgumentException("cannot diff null spec.");
@@ -56,10 +57,16 @@ public class SpecificationDiff {
 		instance.missingEndpoints = convert2EndpointList(pathDiff.getMissing());
 		instance.changedEndpoints = new ArrayList<ChangedEndpoint>();
 
-		Map<String, Object> oldExts = oldSpec.getInfo().getVendorExtensions();
-		Map<String, Object> newExts = newSpec.getInfo().getVendorExtensions();
-		instance.nonPathVendorExtGroup.getChangedSubGroups()
-				.put("Info", getChangedVendorExtsGroup(oldExts, newExts));
+
+		Map<String, Object> oldExts;
+		Map<String, Object> newExts;
+
+		if (withExtensions) {
+			oldExts = oldSpec.getInfo().getVendorExtensions();
+			newExts = newSpec.getInfo().getVendorExtensions();
+			instance.nonPathVendorExtGroup.getChangedSubGroups()
+					.put("info", getChangedVendorExtsGroup(oldExts, newExts));
+		}
 
 		List<String> sharedKey = pathDiff.getSharedKey();
 		ChangedEndpoint changedEndpoint = null;
@@ -69,9 +76,11 @@ public class SpecificationDiff {
 			Path oldPath = oldPaths.get(pathUrl);
 			Path newPath = newPaths.get(pathUrl);
 
-			oldExts = oldPath.getVendorExtensions();
-			newExts = newPath.getVendorExtensions();
-			changedEndpoint.setVendorExtsFromGroup(getChangedVendorExtsGroup(oldExts, newExts));
+			if (withExtensions) {
+				oldExts = oldPath.getVendorExtensions();
+				newExts = newPath.getVendorExtensions();
+				changedEndpoint.setVendorExtsFromGroup(getChangedVendorExtsGroup(oldExts, newExts));
+			}
 
 			Map<HttpMethod, Operation> oldOperationMap = oldPath.getOperationMap();
 			Map<HttpMethod, Operation> newOperationMap = newPath.getOperationMap();
@@ -90,9 +99,11 @@ public class SpecificationDiff {
 				Operation newOperation = newOperationMap.get(method);
 				changedOperation.setSummary(newOperation.getSummary());
 
-				oldExts = oldOperation.getVendorExtensions();
-				newExts = newOperation.getVendorExtensions();
-				changedOperation.setVendorExtsFromGroup(getChangedVendorExtsGroup( oldExts, newExts));
+				if (withExtensions) {
+					oldExts = oldOperation.getVendorExtensions();
+					newExts = newOperation.getVendorExtensions();
+					changedOperation.setVendorExtsFromGroup(getChangedVendorExtsGroup( oldExts, newExts));
+				}
 
 				List<Parameter> oldParameters = oldOperation.getParameters();
 				List<Parameter> newParameters = newOperation.getParameters();
@@ -103,10 +114,12 @@ public class SpecificationDiff {
 				changedOperation.setMissingParameters(parameterDiff.getMissing());
 				changedOperation.setChangedParameter(parameterDiff.getChanged());
 
-				for (ChangedParameter param : parameterDiff.getChanged()) {
-					oldExts = param.getLeftParameter().getVendorExtensions();
-					newExts = param.getRightParameter().getVendorExtensions();
-					param.setVendorExtsFromGroup(getChangedVendorExtsGroup(oldExts, newExts));
+				if (withExtensions) {
+					for (ChangedParameter param : parameterDiff.getChanged()) {
+						oldExts = param.getLeftParameter().getVendorExtensions();
+						newExts = param.getRightParameter().getVendorExtensions();
+						param.setVendorExtsFromGroup(getChangedVendorExtsGroup(oldExts, newExts));
+					}
 				}
 
 				Property oldResponseProperty = getResponseProperty(oldOperation);
@@ -117,16 +130,17 @@ public class SpecificationDiff {
 				changedOperation.setAddProps(propertyDiff.getIncreased());
 				changedOperation.setMissingProps(propertyDiff.getMissing());
 
-				Map<String, Response> oldRes = oldOperation.getResponses();
-				Map<String, Response> newRes = newOperation.getResponses();
-				MapKeyDiff<String, Response> responseDiff = MapKeyDiff.diff(oldRes, newRes);
-				ChangedVendorExtensionGroup responseGroup = new ChangedVendorExtensionGroup();
-				changedOperation.getChangedSubGroups().put("Responses", responseGroup);
-				for (String key : responseDiff.getSharedKey()) {
-					ChangedVendorExtensionGroup group = getChangedVendorExtsGroup(
-							oldRes.get(key).getVendorExtensions(), newRes.get(key).getVendorExtensions());
-
-					responseGroup.getChangedSubGroups().put(key, group);
+				if (withExtensions) {
+					Map<String, Response> oldRes = oldOperation.getResponses();
+					Map<String, Response> newRes = newOperation.getResponses();
+					MapKeyDiff<String, Response> responseDiff = MapKeyDiff.diff(oldRes, newRes);
+					ChangedExtensionGroup responseGroup = new ChangedExtensionGroup();
+					changedOperation.putSubGroup("responses", responseGroup);
+					for (String key : responseDiff.getSharedKey()) {
+						ChangedExtensionGroup group = getChangedVendorExtsGroup(
+								oldRes.get(key).getVendorExtensions(), newRes.get(key).getVendorExtensions());
+						responseGroup.putSubGroup(key, group);
+					}
 				}
 
 				if (changedOperation.isDiff()) {
@@ -145,27 +159,29 @@ public class SpecificationDiff {
 			}
 		}
 
-		ChangedVendorExtensionGroup securityDefsGroup = new ChangedVendorExtensionGroup();
-		Map<String, SecuritySchemeDefinition> oldDefs = oldSpec.getSecurityDefinitions();
-		Map<String, SecuritySchemeDefinition> newDefs = newSpec.getSecurityDefinitions();
+		if (withExtensions) {
+			ChangedExtensionGroup securityDefsGroup = new ChangedExtensionGroup();
+			Map<String, SecuritySchemeDefinition> oldDefs = oldSpec.getSecurityDefinitions();
+			Map<String, SecuritySchemeDefinition> newDefs = newSpec.getSecurityDefinitions();
 
-		MapKeyDiff<String, SecuritySchemeDefinition> securityDefsDiff = MapKeyDiff.diff(oldDefs, newDefs);
-		for (String key : securityDefsDiff.getSharedKey()) {
-			securityDefsGroup.getChangedSubGroups().put(key, getChangedVendorExtsGroup(
-					oldDefs.get(key).getVendorExtensions(), newDefs.get(key).getVendorExtensions()));
+			MapKeyDiff<String, SecuritySchemeDefinition> securityDefsDiff = MapKeyDiff.diff(oldDefs, newDefs);
+			for (String key : securityDefsDiff.getSharedKey()) {
+				securityDefsGroup.getChangedSubGroups().put(key, getChangedVendorExtsGroup(
+						oldDefs.get(key).getVendorExtensions(), newDefs.get(key).getVendorExtensions()));
+			}
+			instance.nonPathVendorExtGroup.getChangedSubGroups().put("securityDefinitions", securityDefsGroup);
+
+			ChangedExtensionGroup tagsGroup = new ChangedExtensionGroup();
+			Map<String, Tag> oldTags = mapTagsByName(oldSpec.getTags());
+			Map<String, Tag> newTags = mapTagsByName(newSpec.getTags());
+
+			MapKeyDiff<String, Tag> tagDiff = MapKeyDiff.diff(oldTags, newTags);
+			for (String key : tagDiff.getSharedKey()) {
+				tagsGroup.getChangedSubGroups().put(key, getChangedVendorExtsGroup(
+						oldSpec.getTag(key).getVendorExtensions(), newSpec.getTag(key).getVendorExtensions()));
+			}
+			instance.nonPathVendorExtGroup.getChangedSubGroups().put("tags", tagsGroup);
 		}
-		instance.nonPathVendorExtGroup.getChangedSubGroups().put("Security Definitions", securityDefsGroup);
-
-		ChangedVendorExtensionGroup tagsGroup = new ChangedVendorExtensionGroup();
-		Map<String, Tag> oldTags = mapTagsByName(oldSpec.getTags());
-		Map<String, Tag> newTags = mapTagsByName(newSpec.getTags());
-
-		MapKeyDiff<String, Tag> tagDiff = MapKeyDiff.diff(oldTags, newTags);
-		for (String key : tagDiff.getSharedKey()) {
-			tagsGroup.getChangedSubGroups().put(key, getChangedVendorExtsGroup(
-					oldSpec.getTag(key).getVendorExtensions(), newSpec.getTag(key).getVendorExtensions()));
-		}
-		instance.nonPathVendorExtGroup.getChangedSubGroups().put("Tags", tagsGroup);
 
 		return instance;
 
@@ -179,10 +195,10 @@ public class SpecificationDiff {
 		return mappedTags;
 	}
 
-	private static ChangedVendorExtensionGroup getChangedVendorExtsGroup(
+	private static ChangedExtensionGroup getChangedVendorExtsGroup(
 			Map<String, Object> oldExts, Map<String, Object> newExts) {
 		MapDiff<String, Object> mapDiff = MapDiff.diff(oldExts, newExts);
-		ChangedVendorExtensionGroup group = new ChangedVendorExtensionGroup();
+		ChangedExtensionGroup group = new ChangedExtensionGroup();
 		group.setMissingVendorExtensions(mapDiff.getMissing());
 		group.setIncreasedVendorExtensions(mapDiff.getIncreased());
 		group.setChangedVendorExtensions(mapDiff.getChanged());
@@ -252,7 +268,7 @@ public class SpecificationDiff {
 		return changedEndpoints;
 	}
 
-	public ChangedVendorExtensionGroup getNonPathVendorExtGroup() {
+	public ChangedExtensionGroup getNonPathVendorExtGroup() {
 		return nonPathVendorExtGroup;
 	}
 }

--- a/src/main/java/com/deepoove/swagger/diff/compare/SpecificationDiff.java
+++ b/src/main/java/com/deepoove/swagger/diff/compare/SpecificationDiff.java
@@ -42,7 +42,7 @@ public class SpecificationDiff {
 	}
 
 	public static SpecificationDiff diff(Swagger oldSpec, Swagger newSpec) {
-		return diff(oldSpec, newSpec, true);
+		return diff(oldSpec, newSpec, false);
 	}
 
 	public static SpecificationDiff diff(Swagger oldSpec, Swagger newSpec, boolean withExtensions) {

--- a/src/main/java/com/deepoove/swagger/diff/compare/SpecificationDiff.java
+++ b/src/main/java/com/deepoove/swagger/diff/compare/SpecificationDiff.java
@@ -8,8 +8,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import org.apache.commons.lang3.tuple.Pair;
-
 import com.deepoove.swagger.diff.model.ChangedEndpoint;
 import com.deepoove.swagger.diff.model.ChangedExtensionGroup;
 import com.deepoove.swagger.diff.model.ChangedOperation;
@@ -17,13 +15,11 @@ import com.deepoove.swagger.diff.model.ChangedParameter;
 import com.deepoove.swagger.diff.model.Endpoint;
 
 import io.swagger.models.HttpMethod;
-import io.swagger.models.Info;
 import io.swagger.models.Operation;
 import io.swagger.models.Path;
 import io.swagger.models.Response;
 import io.swagger.models.Swagger;
 import io.swagger.models.Tag;
-import io.swagger.models.auth.SecuritySchemeDefinition;
 import io.swagger.models.parameters.Parameter;
 import io.swagger.models.properties.Property;
 
@@ -143,6 +139,9 @@ public class SpecificationDiff extends ChangedExtensionGroup {
 
 	private static Map<String, Tag> mapTagsByName(List<Tag> tags) {
 		Map<String, Tag> mappedTags = new LinkedHashMap<String, Tag>();
+		if (tags == null) {
+			return mappedTags;
+		}
 		for (Tag tag : tags) {
 			mappedTags.put(tag.getName(), tag);
 		}

--- a/src/main/java/com/deepoove/swagger/diff/compare/SpecificationDiff.java
+++ b/src/main/java/com/deepoove/swagger/diff/compare/SpecificationDiff.java
@@ -57,8 +57,6 @@ public class SpecificationDiff {
 		instance.missingEndpoints = convert2EndpointList(pathDiff.getMissing());
 		instance.changedEndpoints = new ArrayList<ChangedEndpoint>();
 
-		System.out.println(oldSpec.getVendorExtensions());
-
 		Map<String, Object> oldExts;
 		Map<String, Object> newExts;
 

--- a/src/main/java/com/deepoove/swagger/diff/compare/SpecificationDiff.java
+++ b/src/main/java/com/deepoove/swagger/diff/compare/SpecificationDiff.java
@@ -30,13 +30,11 @@ import io.swagger.models.properties.Property;
  * @author Sayi
  *
  */
-public class SpecificationDiff {
+public class SpecificationDiff extends ChangedExtensionGroup {
 
 	private List<Endpoint> newEndpoints;
 	private List<Endpoint> missingEndpoints;
 	private List<ChangedEndpoint> changedEndpoints;
-
-	private ChangedExtensionGroup nonPathVendorExtGroup = new ChangedExtensionGroup();
 
 	private SpecificationDiff() {
 	}
@@ -64,11 +62,11 @@ public class SpecificationDiff {
 
 			oldExts = oldSpec.getVendorExtensions();
 			newExts = newSpec.getVendorExtensions();
-			instance.nonPathVendorExtGroup.setVendorExtsFromGroup(getChangedVendorExtsGroup( oldExts, newExts));
+			instance.setVendorExtsFromGroup(getChangedVendorExtsGroup(oldExts, newExts));
 
 			oldExts = oldSpec.getInfo().getVendorExtensions();
 			newExts = newSpec.getInfo().getVendorExtensions();
-			instance.nonPathVendorExtGroup.getChangedSubGroups()
+			instance.getChangedSubGroups()
 					.put("info", getChangedVendorExtsGroup(oldExts, newExts));
 		}
 
@@ -173,7 +171,7 @@ public class SpecificationDiff {
 				securityDefsGroup.getChangedSubGroups().put(key, getChangedVendorExtsGroup(
 						oldDefs.get(key).getVendorExtensions(), newDefs.get(key).getVendorExtensions()));
 			}
-			instance.nonPathVendorExtGroup.getChangedSubGroups().put("securityDefinitions", securityDefsGroup);
+			instance.getChangedSubGroups().put("securityDefinitions", securityDefsGroup);
 
 			ChangedExtensionGroup tagsGroup = new ChangedExtensionGroup();
 			Map<String, Tag> oldTags = mapTagsByName(oldSpec.getTags());
@@ -184,7 +182,7 @@ public class SpecificationDiff {
 				tagsGroup.getChangedSubGroups().put(key, getChangedVendorExtsGroup(
 						oldSpec.getTag(key).getVendorExtensions(), newSpec.getTag(key).getVendorExtensions()));
 			}
-			instance.nonPathVendorExtGroup.getChangedSubGroups().put("tags", tagsGroup);
+			instance.getChangedSubGroups().put("tags", tagsGroup);
 		}
 
 		return instance;
@@ -270,9 +268,5 @@ public class SpecificationDiff {
 
 	public List<ChangedEndpoint> getChangedEndpoints() {
 		return changedEndpoints;
-	}
-
-	public ChangedExtensionGroup getNonPathVendorExtGroup() {
-		return nonPathVendorExtGroup;
 	}
 }

--- a/src/main/java/com/deepoove/swagger/diff/compare/SpecificationDiff.java
+++ b/src/main/java/com/deepoove/swagger/diff/compare/SpecificationDiff.java
@@ -48,7 +48,7 @@ public class SpecificationDiff extends ChangedExtensionGroup {
 
 	public static SpecificationDiff diff(Swagger oldSpec, Swagger newSpec, boolean withExtensions) {
 		SpecificationDiff instance = new SpecificationDiff();
-		VendorExtDiffer extDiffer = new VendorExtDiffer(withExtensions);
+		VendorExtensionDiff extDiffer = new VendorExtensionDiff(withExtensions);
 		if (null == oldSpec || null == newSpec) {
 			throw new IllegalArgumentException("cannot diff null spec.");
 		}
@@ -210,93 +210,5 @@ public class SpecificationDiff extends ChangedExtensionGroup {
 
 	public List<ChangedEndpoint> getChangedEndpoints() {
 		return changedEndpoints;
-	}
-
-	private static class VendorExtDiffer {
-
-		private boolean withExts;
-
-		private VendorExtDiffer(boolean withExts) {
-			this.withExts = withExts;
-		}
-
-		public ChangedExtensionGroup diff(Parameter left, Parameter right) {
-			return diff(left.getVendorExtensions(), right.getVendorExtensions());
-		}
-
-		public ChangedExtensionGroup diff(Operation left, Operation right) {
-			return diff(left.getVendorExtensions(), right.getVendorExtensions());
-		}
-
-		public ChangedExtensionGroup diff(Swagger left, Swagger right) {
-			return diff(left.getVendorExtensions(), right.getVendorExtensions());
-		}
-
-		public ChangedExtensionGroup diff(Info left, Info right) {
-			return diff(left.getVendorExtensions(), right.getVendorExtensions());
-		}
-
-		public ChangedExtensionGroup diff(Path left, Path right) {
-			return diff(left.getVendorExtensions(), right.getVendorExtensions());
-		}
-
-		public ChangedExtensionGroup diff(Response left, Response right) {
-			return diff(left.getVendorExtensions(), right.getVendorExtensions());
-		}
-
-		public ChangedExtensionGroup diff(Tag left ,Tag right) {
-			return diff(left.getVendorExtensions(), right.getVendorExtensions());
-		}
-
-		public ChangedExtensionGroup diff(SecuritySchemeDefinition left, SecuritySchemeDefinition right) {
-			return diff(left.getVendorExtensions(), right.getVendorExtensions());
-		}
-
-		private ChangedExtensionGroup diff(Map<String, Object> oldExts, Map<String, Object> newExts) {
-			ChangedExtensionGroup group = new ChangedExtensionGroup();
-			if (withExts) {
-				MapDiff<String, Object> mapDiff = MapDiff.diff(oldExts, newExts);
-				group.setMissingVendorExtensions(mapDiff.getMissing());
-				group.setChangedVendorExtensions(mapDiff.getChanged());
-				group.setIncreasedVendorExtensions(mapDiff.getIncreased());
-			}
-			return group;
-		}
-
-		public ChangedExtensionGroup diffTagGroup(Map<String, Tag> left, Map<String, Tag> right) {
-			MapDiff<String, Tag> responseDiff = MapDiff.diff(left, right);
-			ChangedExtensionGroup responseGroup = new ChangedExtensionGroup();
-			for (Entry<String, Pair<Tag, Tag>> entry : responseDiff.getChanged().entrySet()) {
-				String code = entry.getKey();
-				Tag oldVal = entry.getValue().getLeft();
-				Tag newVal = entry.getValue().getRight();
-				responseGroup.putSubGroup(code, diff(oldVal, newVal));
-			}
-			return responseGroup;
-		}
-
-		public ChangedExtensionGroup diffSecGroup(Map<String, SecuritySchemeDefinition> left, Map<String, SecuritySchemeDefinition> right) {
-			MapDiff<String, SecuritySchemeDefinition> responseDiff = MapDiff.diff(left, right);
-			ChangedExtensionGroup responseGroup = new ChangedExtensionGroup();
-			for (Entry<String, Pair<SecuritySchemeDefinition, SecuritySchemeDefinition>> entry : responseDiff.getChanged().entrySet()) {
-				String code = entry.getKey();
-				SecuritySchemeDefinition oldVal = entry.getValue().getLeft();
-				SecuritySchemeDefinition newVal = entry.getValue().getRight();
-				responseGroup.putSubGroup(code, diff(oldVal, newVal));
-			}
-			return responseGroup;
-		}
-
-		public ChangedExtensionGroup diffResGroup(Map<String, Response> left, Map<String, Response> right) {
-			MapDiff<String, Response> responseDiff = MapDiff.diff(left, right);
-			ChangedExtensionGroup responseGroup = new ChangedExtensionGroup();
-			for (Entry<String, Pair<Response, Response>> entry : responseDiff.getChanged().entrySet()) {
-				String code = entry.getKey();
-				Response oldVal = entry.getValue().getLeft();
-				Response newVal = entry.getValue().getRight();
-				responseGroup.putSubGroup(code, diff(oldVal, newVal));
-			}
-			return responseGroup;
-		}
 	}
 }

--- a/src/main/java/com/deepoove/swagger/diff/compare/VendorExtensionDiff.java
+++ b/src/main/java/com/deepoove/swagger/diff/compare/VendorExtensionDiff.java
@@ -1,0 +1,105 @@
+package com.deepoove.swagger.diff.compare;
+
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.apache.commons.lang3.tuple.Pair;
+
+import com.deepoove.swagger.diff.model.ChangedExtensionGroup;
+
+import io.swagger.models.Info;
+import io.swagger.models.Operation;
+import io.swagger.models.Path;
+import io.swagger.models.Response;
+import io.swagger.models.Swagger;
+import io.swagger.models.Tag;
+import io.swagger.models.auth.SecuritySchemeDefinition;
+import io.swagger.models.parameters.Parameter;
+
+public class VendorExtensionDiff {
+
+  private boolean withExts;
+
+  public VendorExtensionDiff(boolean withExts) {
+    this.withExts = withExts;
+  }
+
+  public ChangedExtensionGroup diff(Parameter left, Parameter right) {
+    return diff(left.getVendorExtensions(), right.getVendorExtensions());
+  }
+
+  public ChangedExtensionGroup diff(Operation left, Operation right) {
+    return diff(left.getVendorExtensions(), right.getVendorExtensions());
+  }
+
+  public ChangedExtensionGroup diff(Swagger left, Swagger right) {
+    return diff(left.getVendorExtensions(), right.getVendorExtensions());
+  }
+
+  public ChangedExtensionGroup diff(Info left, Info right) {
+    return diff(left.getVendorExtensions(), right.getVendorExtensions());
+  }
+
+  public ChangedExtensionGroup diff(Path left, Path right) {
+    return diff(left.getVendorExtensions(), right.getVendorExtensions());
+  }
+
+  public ChangedExtensionGroup diff(Response left, Response right) {
+    return diff(left.getVendorExtensions(), right.getVendorExtensions());
+  }
+
+  public ChangedExtensionGroup diff(Tag left , Tag right) {
+    return diff(left.getVendorExtensions(), right.getVendorExtensions());
+  }
+
+  public ChangedExtensionGroup diff(SecuritySchemeDefinition left, SecuritySchemeDefinition right) {
+    return diff(left.getVendorExtensions(), right.getVendorExtensions());
+  }
+
+  private ChangedExtensionGroup diff(Map<String, Object> oldExts, Map<String, Object> newExts) {
+    ChangedExtensionGroup group = new ChangedExtensionGroup();
+    if (withExts) {
+      MapDiff<String, Object> mapDiff = MapDiff.diff(oldExts, newExts);
+      group.setMissingVendorExtensions(mapDiff.getMissing());
+      group.setChangedVendorExtensions(mapDiff.getChanged());
+      group.setIncreasedVendorExtensions(mapDiff.getIncreased());
+    }
+    return group;
+  }
+
+  public ChangedExtensionGroup diffTagGroup(Map<String, Tag> left, Map<String, Tag> right) {
+    MapDiff<String, Tag> responseDiff = MapDiff.diff(left, right);
+    ChangedExtensionGroup responseGroup = new ChangedExtensionGroup();
+    for (Entry<String, Pair<Tag, Tag>> entry : responseDiff.getChanged().entrySet()) {
+      String code = entry.getKey();
+      Tag oldVal = entry.getValue().getLeft();
+      Tag newVal = entry.getValue().getRight();
+      responseGroup.putSubGroup(code, diff(oldVal, newVal));
+    }
+    return responseGroup;
+  }
+
+  public ChangedExtensionGroup diffSecGroup(Map<String, SecuritySchemeDefinition> left, Map<String, SecuritySchemeDefinition> right) {
+    MapDiff<String, SecuritySchemeDefinition> responseDiff = MapDiff.diff(left, right);
+    ChangedExtensionGroup responseGroup = new ChangedExtensionGroup();
+    for (Entry<String, Pair<SecuritySchemeDefinition, SecuritySchemeDefinition>> entry : responseDiff.getChanged().entrySet()) {
+      String code = entry.getKey();
+      SecuritySchemeDefinition oldVal = entry.getValue().getLeft();
+      SecuritySchemeDefinition newVal = entry.getValue().getRight();
+      responseGroup.putSubGroup(code, diff(oldVal, newVal));
+    }
+    return responseGroup;
+  }
+
+  public ChangedExtensionGroup diffResGroup(Map<String, Response> left, Map<String, Response> right) {
+    MapDiff<String, Response> responseDiff = MapDiff.diff(left, right);
+    ChangedExtensionGroup responseGroup = new ChangedExtensionGroup();
+    for (Entry<String, Pair<Response, Response>> entry : responseDiff.getChanged().entrySet()) {
+      String code = entry.getKey();
+      Response oldVal = entry.getValue().getLeft();
+      Response newVal = entry.getValue().getRight();
+      responseGroup.putSubGroup(code, diff(oldVal, newVal));
+    }
+    return responseGroup;
+  }
+}

--- a/src/main/java/com/deepoove/swagger/diff/model/ChangedEndpoint.java
+++ b/src/main/java/com/deepoove/swagger/diff/model/ChangedEndpoint.java
@@ -5,7 +5,7 @@ import java.util.Map;
 import io.swagger.models.HttpMethod;
 import io.swagger.models.Operation;
 
-public class ChangedEndpoint extends ChangedVendorExtensionGroup implements Changed {
+public class ChangedEndpoint extends ChangedExtensionGroup implements Changed {
 
 	private String pathUrl;
 

--- a/src/main/java/com/deepoove/swagger/diff/model/ChangedEndpoint.java
+++ b/src/main/java/com/deepoove/swagger/diff/model/ChangedEndpoint.java
@@ -5,13 +5,12 @@ import java.util.Map;
 import io.swagger.models.HttpMethod;
 import io.swagger.models.Operation;
 
-public class ChangedEndpoint implements Changed{
+public class ChangedEndpoint extends ChangedVendorExtensionGroup implements Changed {
 
 	private String pathUrl;
 
 	private Map<HttpMethod, Operation> newOperations;
 	private Map<HttpMethod, Operation> missingOperations;
-
 	private Map<HttpMethod, ChangedOperation> changedOperations;
 
 	public Map<HttpMethod, Operation> getNewOperations() {
@@ -53,7 +52,7 @@ public class ChangedEndpoint implements Changed{
 //		newOperations.isEmpty() 
 //		|| !missingOperations.isEmpty()
 //		|| 
-		return !changedOperations.isEmpty();
+		return !changedOperations.isEmpty() || vendorExtensionsAreDiff();
 	}
 
 }

--- a/src/main/java/com/deepoove/swagger/diff/model/ChangedExtensionGroup.java
+++ b/src/main/java/com/deepoove/swagger/diff/model/ChangedExtensionGroup.java
@@ -5,13 +5,11 @@ import java.util.Map;
 
 import org.apache.commons.lang3.tuple.Pair;
 
-import com.deepoove.swagger.diff.compare.MapDiff;
-
-public class ChangedVendorExtensionGroup {
+public class ChangedExtensionGroup {
   protected Map<String, Object> increasedVendorExtensions = new LinkedHashMap<String, Object>();
   protected Map<String, Object> missingVendorExtensions = new LinkedHashMap<String, Object>();
   protected Map<String, Pair<Object, Object>> changedVendorExtensions = new LinkedHashMap<String, Pair<Object, Object>>();
-  protected Map<String, ChangedVendorExtensionGroup> changedSubGroups = new LinkedHashMap<String, ChangedVendorExtensionGroup>();
+  protected Map<String, ChangedExtensionGroup> changedSubGroups = new LinkedHashMap<String, ChangedExtensionGroup>();
 
   public boolean vendorExtensionsAreDiff() {
     return !increasedVendorExtensions.isEmpty()
@@ -22,7 +20,7 @@ public class ChangedVendorExtensionGroup {
 
   private boolean subVendorExtensionsAreDiff() {
     boolean accumulator = false;
-    for (ChangedVendorExtensionGroup subgroup : changedSubGroups.values()) {
+    for (ChangedExtensionGroup subgroup : changedSubGroups.values()) {
       accumulator = accumulator || subgroup.vendorExtensionsAreDiff();
     }
     return accumulator;
@@ -52,11 +50,23 @@ public class ChangedVendorExtensionGroup {
     this.changedVendorExtensions = changedVendorExtensions;
   }
 
-  public Map<String, ChangedVendorExtensionGroup> getChangedSubGroups() {
+  public Map<String, ChangedExtensionGroup> getChangedSubGroups() {
     return changedSubGroups;
   }
 
-  public void setVendorExtsFromGroup(ChangedVendorExtensionGroup newDiffs) {
+  public boolean hasSubGroup(String key) {
+    return changedSubGroups.containsKey(key);
+  }
+
+  public ChangedExtensionGroup getSubGroup(String key) {
+    return changedSubGroups.get(key);
+  }
+
+  public void putSubGroup(String key, ChangedExtensionGroup group) {
+    changedSubGroups.put(key, group);
+  }
+
+  public void setVendorExtsFromGroup(ChangedExtensionGroup newDiffs) {
     this.increasedVendorExtensions = newDiffs.getIncreasedVendorExtensions();
     this.missingVendorExtensions = newDiffs.getMissingVendorExtensions();
     this.changedVendorExtensions = newDiffs.getChangedVendorExtensions();

--- a/src/main/java/com/deepoove/swagger/diff/model/ChangedExtensionGroup.java
+++ b/src/main/java/com/deepoove/swagger/diff/model/ChangedExtensionGroup.java
@@ -11,10 +11,14 @@ public class ChangedExtensionGroup {
   protected Map<String, Pair<Object, Object>> changedVendorExtensions = new LinkedHashMap<String, Pair<Object, Object>>();
   protected Map<String, ChangedExtensionGroup> changedSubGroups = new LinkedHashMap<String, ChangedExtensionGroup>();
 
+  public boolean vendorExtensionsAreDiffShallow() {
+    return !(increasedVendorExtensions.isEmpty()
+        && changedVendorExtensions.isEmpty()
+        && missingVendorExtensions.isEmpty());
+  }
+
   public boolean vendorExtensionsAreDiff() {
-    return !increasedVendorExtensions.isEmpty()
-        || !changedVendorExtensions.isEmpty()
-        || !missingVendorExtensions.isEmpty()
+    return vendorExtensionsAreDiffShallow()
         || subVendorExtensionsAreDiff();
   }
 

--- a/src/main/java/com/deepoove/swagger/diff/model/ChangedOperation.java
+++ b/src/main/java/com/deepoove/swagger/diff/model/ChangedOperation.java
@@ -5,7 +5,7 @@ import java.util.List;
 
 import io.swagger.models.parameters.Parameter;
 
-public class ChangedOperation extends ChangedVendorExtensionGroup implements Changed {
+public class ChangedOperation extends ChangedExtensionGroup implements Changed {
 
 	private String summary;
 

--- a/src/main/java/com/deepoove/swagger/diff/model/ChangedOperation.java
+++ b/src/main/java/com/deepoove/swagger/diff/model/ChangedOperation.java
@@ -5,7 +5,7 @@ import java.util.List;
 
 import io.swagger.models.parameters.Parameter;
 
-public class ChangedOperation implements Changed {
+public class ChangedOperation extends ChangedVendorExtensionGroup implements Changed {
 
 	private String summary;
 
@@ -16,6 +16,7 @@ public class ChangedOperation implements Changed {
 
 	private List<ElProperty> addProps = new ArrayList<ElProperty>();
 	private List<ElProperty> missingProps = new ArrayList<ElProperty>();
+	private List<ElProperty> changedProps = new ArrayList<ElProperty>();
 
 	public List<Parameter> getAddParameters() {
 		return addParameters;
@@ -57,6 +58,14 @@ public class ChangedOperation implements Changed {
 		this.missingProps = missingProps;
 	}
 
+	public List<ElProperty> getChangedProps() {
+		return changedProps;
+	}
+
+	public void setChangedProps(List<ElProperty> changedProps) {
+		this.changedProps = changedProps;
+	}
+
 	public String getSummary() {
 		return summary;
 	}
@@ -68,12 +77,22 @@ public class ChangedOperation implements Changed {
 	public boolean isDiff() {
 		return !addParameters.isEmpty() || !missingParameters.isEmpty()
 				|| !changedParameter.isEmpty() || !addProps.isEmpty()
-				|| !missingProps.isEmpty();
+				|| !missingProps.isEmpty() || vendorExtensionsAreDiff();
 	}
 	public boolean isDiffProp(){
 		return !addProps.isEmpty()
-				|| !missingProps.isEmpty();
+				|| !missingProps.isEmpty()
+				|| propVendorExtsAreDiff();
 	}
+
+	public boolean propVendorExtsAreDiff() {
+		boolean accumulator = false;
+		for (ElProperty prop : changedProps) {
+			accumulator = accumulator || prop.vendorExtensionsAreDiff();
+		}
+		return accumulator;
+	}
+
 	public boolean isDiffParam(){
 		return !addParameters.isEmpty() || !missingParameters.isEmpty()
 				|| !changedParameter.isEmpty();

--- a/src/main/java/com/deepoove/swagger/diff/model/ChangedParameter.java
+++ b/src/main/java/com/deepoove/swagger/diff/model/ChangedParameter.java
@@ -5,7 +5,7 @@ import java.util.List;
 
 import io.swagger.models.parameters.Parameter;
 
-public class ChangedParameter extends ChangedVendorExtensionGroup implements Changed {
+public class ChangedParameter extends ChangedExtensionGroup implements Changed {
 	
 	private List<ElProperty> increased = new ArrayList<ElProperty>();
 	private List<ElProperty> missing = new ArrayList<ElProperty>();;

--- a/src/main/java/com/deepoove/swagger/diff/model/ChangedParameter.java
+++ b/src/main/java/com/deepoove/swagger/diff/model/ChangedParameter.java
@@ -5,7 +5,7 @@ import java.util.List;
 
 import io.swagger.models.parameters.Parameter;
 
-public class ChangedParameter implements Changed {
+public class ChangedParameter extends ChangedVendorExtensionGroup implements Changed {
 	
 	private List<ElProperty> increased = new ArrayList<ElProperty>();
 	private List<ElProperty> missing = new ArrayList<ElProperty>();;
@@ -50,7 +50,7 @@ public class ChangedParameter implements Changed {
 	}
 
 	public boolean isDiff() {
-		return isChangeRequired || isChangeDescription || !increased.isEmpty() || !missing.isEmpty();
+		return isChangeRequired || isChangeDescription || !increased.isEmpty() || !missing.isEmpty() || vendorExtensionsAreDiff();
 	}
 
 	public List<ElProperty> getIncreased() {

--- a/src/main/java/com/deepoove/swagger/diff/model/ChangedVendorExtensionGroup.java
+++ b/src/main/java/com/deepoove/swagger/diff/model/ChangedVendorExtensionGroup.java
@@ -1,0 +1,64 @@
+package com.deepoove.swagger.diff.model;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.apache.commons.lang3.tuple.Pair;
+
+import com.deepoove.swagger.diff.compare.MapDiff;
+
+public class ChangedVendorExtensionGroup {
+  protected Map<String, Object> increasedVendorExtensions = new LinkedHashMap<String, Object>();
+  protected Map<String, Object> missingVendorExtensions = new LinkedHashMap<String, Object>();
+  protected Map<String, Pair<Object, Object>> changedVendorExtensions = new LinkedHashMap<String, Pair<Object, Object>>();
+  protected Map<String, ChangedVendorExtensionGroup> changedSubGroups = new LinkedHashMap<String, ChangedVendorExtensionGroup>();
+
+  public boolean vendorExtensionsAreDiff() {
+    return !increasedVendorExtensions.isEmpty()
+        || !changedVendorExtensions.isEmpty()
+        || !missingVendorExtensions.isEmpty()
+        || subVendorExtensionsAreDiff();
+  }
+
+  private boolean subVendorExtensionsAreDiff() {
+    boolean accumulator = false;
+    for (ChangedVendorExtensionGroup subgroup : changedSubGroups.values()) {
+      accumulator = accumulator || subgroup.vendorExtensionsAreDiff();
+    }
+    return accumulator;
+  }
+
+  public Map<String, Object> getIncreasedVendorExtensions() {
+    return increasedVendorExtensions;
+  }
+
+  public void setIncreasedVendorExtensions(Map<String, Object> increasedVendorExtensions) {
+    this.increasedVendorExtensions = increasedVendorExtensions;
+  }
+
+  public Map<String, Object> getMissingVendorExtensions() {
+    return missingVendorExtensions;
+  }
+
+  public void setMissingVendorExtensions(Map<String, Object> missingVendorExtensions) {
+    this.missingVendorExtensions = missingVendorExtensions;
+  }
+
+  public Map<String, Pair<Object, Object>> getChangedVendorExtensions() {
+    return changedVendorExtensions;
+  }
+
+  public void setChangedVendorExtensions(Map<String, Pair<Object, Object>> changedVendorExtensions) {
+    this.changedVendorExtensions = changedVendorExtensions;
+  }
+
+  public Map<String, ChangedVendorExtensionGroup> getChangedSubGroups() {
+    return changedSubGroups;
+  }
+
+  public void setVendorExtsFromGroup(ChangedVendorExtensionGroup newDiffs) {
+    this.increasedVendorExtensions = newDiffs.getIncreasedVendorExtensions();
+    this.missingVendorExtensions = newDiffs.getMissingVendorExtensions();
+    this.changedVendorExtensions = newDiffs.getChangedVendorExtensions();
+  }
+}

--- a/src/main/java/com/deepoove/swagger/diff/model/ElProperty.java
+++ b/src/main/java/com/deepoove/swagger/diff/model/ElProperty.java
@@ -7,7 +7,7 @@ import io.swagger.models.properties.Property;
  * @author Sayi
  * @version 
  */
-public class ElProperty extends ChangedVendorExtensionGroup {
+public class ElProperty extends ChangedExtensionGroup {
 
 	private String el;
 

--- a/src/main/java/com/deepoove/swagger/diff/model/ElProperty.java
+++ b/src/main/java/com/deepoove/swagger/diff/model/ElProperty.java
@@ -7,7 +7,7 @@ import io.swagger.models.properties.Property;
  * @author Sayi
  * @version 
  */
-public class ElProperty {
+public class ElProperty extends ChangedVendorExtensionGroup {
 
 	private String el;
 

--- a/src/main/java/com/deepoove/swagger/diff/output/HtmlRender.java
+++ b/src/main/java/com/deepoove/swagger/diff/output/HtmlRender.java
@@ -116,25 +116,29 @@ public class HtmlRender implements Render {
         ContainerTag container = div().withId("changed");
         ChangedExtensionGroup group;
 
-        ChangedExtensionGroup topLevelExts = diff.getChangedTopLevelVendorExtensions();
+        ChangedExtensionGroup topLevelExts = diff.getChangedVendorExtensions();
+        if (topLevelExts.vendorExtensionsAreDiffShallow()) {
+            container.with(li().withClass("indent")).withText("root-level extensions")
+                .with(ul_changedVendorExtList(topLevelExts, true, true));
+        }
         if (topLevelExts.hasSubGroup("info")) {
             group = topLevelExts.getSubGroup("info");
             if (group.vendorExtensionsAreDiff()) {
-                container.with(li().withClass("indent").withText("info")
+                container.with(li().withClass("indent").withText("info extensions")
                         .with(ul_changedVendorExtList(group, false, true)));
             }
         }
         if (topLevelExts.hasSubGroup("securityDefinitions")) {
             group = topLevelExts.getSubGroup("securityDefinitions");
             if (group.vendorExtensionsAreDiff()) {
-                container.with(li().withClass("indent").withText("securityDefinitions"))
+                container.with(li().withClass("indent").withText("securityDefinitions extensions"))
                         .with(ul_changedVendorExtMap(group, true));
             }
         }
         if (topLevelExts.hasSubGroup("tags")) {
             group = topLevelExts.getSubGroup("tags");
             if (group.vendorExtensionsAreDiff()) {
-                container.with(li().withClass("indent").withText("tags"))
+                container.with(li().withClass("indent").withText("tags extensions"))
                         .with(ul_changedVendorExtMap(group, true));
             }
         }

--- a/src/main/java/com/deepoove/swagger/diff/output/HtmlRender.java
+++ b/src/main/java/com/deepoove/swagger/diff/output/HtmlRender.java
@@ -1,20 +1,25 @@
 package com.deepoove.swagger.diff.output;
 
-import com.deepoove.swagger.diff.SwaggerDiff;
-import com.deepoove.swagger.diff.model.*;
-import io.swagger.models.HttpMethod;
-import io.swagger.models.parameters.Parameter;
-import io.swagger.models.properties.Property;
-import j2html.tags.ContainerTag;
-
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import static j2html.TagCreator.*;
-
 import org.apache.commons.lang3.tuple.Pair;
+
+import com.deepoove.swagger.diff.SwaggerDiff;
+import com.deepoove.swagger.diff.model.ChangedEndpoint;
+import com.deepoove.swagger.diff.model.ChangedExtensionGroup;
+import com.deepoove.swagger.diff.model.ChangedOperation;
+import com.deepoove.swagger.diff.model.ChangedParameter;
+import com.deepoove.swagger.diff.model.ElProperty;
+import com.deepoove.swagger.diff.model.Endpoint;
+
+import io.swagger.models.HttpMethod;
+import io.swagger.models.parameters.Parameter;
+import io.swagger.models.properties.Property;
+import j2html.tags.ContainerTag;
+import static j2html.TagCreator.*;
 
 public class HtmlRender implements Render {
 
@@ -118,27 +123,28 @@ public class HtmlRender implements Render {
 
         ChangedExtensionGroup topLevelExts = diff.getChangedVendorExtensions();
         if (topLevelExts.vendorExtensionsAreDiffShallow()) {
-            container.with(li().withClass("indent")).withText("root-level extensions")
+            container.with(li().withClass("indent"))
+                .with(span("Root-Level Extensions").withClass("indent"))
                 .with(ul_changedVendorExtList(topLevelExts, true, true));
         }
         if (topLevelExts.hasSubGroup("info")) {
             group = topLevelExts.getSubGroup("info");
             if (group.vendorExtensionsAreDiff()) {
-                container.with(li().withClass("indent").withText("info extensions")
+                container.with(li().withClass("indent").withText("Info Extensions")
                         .with(ul_changedVendorExtList(group, false, true)));
             }
         }
         if (topLevelExts.hasSubGroup("securityDefinitions")) {
             group = topLevelExts.getSubGroup("securityDefinitions");
             if (group.vendorExtensionsAreDiff()) {
-                container.with(li().withClass("indent").withText("securityDefinitions extensions"))
+                container.with(li().withClass("indent").withText("Security Definition Extensions"))
                         .with(ul_changedVendorExtMap(group, true));
             }
         }
         if (topLevelExts.hasSubGroup("tags")) {
             group = topLevelExts.getSubGroup("tags");
             if (group.vendorExtensionsAreDiff()) {
-                container.with(li().withClass("indent").withText("tags extensions"))
+                container.with(li().withClass("indent").withText("Tag Extensions"))
                         .with(ul_changedVendorExtMap(group, true));
             }
         }

--- a/src/main/java/com/deepoove/swagger/diff/output/HtmlRender.java
+++ b/src/main/java/com/deepoove/swagger/diff/output/HtmlRender.java
@@ -114,22 +114,29 @@ public class HtmlRender implements Render {
         ContainerTag ol_changed = ol_changed(changedEndpoints);
 
         ContainerTag container = div().withId("changed");
+        ChangedExtensionGroup group;
 
         ChangedExtensionGroup topLevelExts = diff.getChangedTopLevelVendorExtensions();
-        ChangedExtensionGroup group = topLevelExts.getSubGroup("info");
-        if (group.vendorExtensionsAreDiff()) {
-            container.with(li().withClass("indent").withText("info")
-                .with(ul_changedVendorExtList(group, false, true)));
+        if (topLevelExts.hasSubGroup("info")) {
+            group = topLevelExts.getSubGroup("info");
+            if (group.vendorExtensionsAreDiff()) {
+                container.with(li().withClass("indent").withText("info")
+                        .with(ul_changedVendorExtList(group, false, true)));
+            }
         }
-        group = topLevelExts.getSubGroup("securityDefinitions");
-        if (group.vendorExtensionsAreDiff()) {
-            container.with(li().withClass("indent").withText("securityDefinitions"))
-                .with(ul_changedVendorExtMap(group, true));
+        if (topLevelExts.hasSubGroup("securityDefinitions")) {
+            group = topLevelExts.getSubGroup("securityDefinitions");
+            if (group.vendorExtensionsAreDiff()) {
+                container.with(li().withClass("indent").withText("securityDefinitions"))
+                        .with(ul_changedVendorExtMap(group, true));
+            }
         }
-        group = topLevelExts.getSubGroup("tags");
-        if (group.vendorExtensionsAreDiff()) {
-            container.with(li().withClass("indent").withText("tags"))
-                .with(ul_changedVendorExtMap(group, true));
+        if (topLevelExts.hasSubGroup("tags")) {
+            group = topLevelExts.getSubGroup("tags");
+            if (group.vendorExtensionsAreDiff()) {
+                container.with(li().withClass("indent").withText("tags"))
+                        .with(ul_changedVendorExtMap(group, true));
+            }
         }
 
         return container.with(ol_changed);

--- a/src/main/java/com/deepoove/swagger/diff/output/HtmlRender.java
+++ b/src/main/java/com/deepoove/swagger/diff/output/HtmlRender.java
@@ -7,11 +7,14 @@ import io.swagger.models.parameters.Parameter;
 import io.swagger.models.properties.Property;
 import j2html.tags.ContainerTag;
 
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
 import static j2html.TagCreator.*;
+
+import org.apache.commons.lang3.tuple.Pair;
 
 public class HtmlRender implements Render {
 
@@ -35,12 +38,11 @@ public class HtmlRender implements Render {
         List<Endpoint> missingEndpoints = diff.getMissingEndpoints();
         ContainerTag ol_missingEndpoint = ol_missingEndpoint(missingEndpoints);
 
-        List<ChangedEndpoint> changedEndpoints = diff.getChangedEndpoints();
-        ContainerTag ol_changed = ol_changed(changedEndpoints);
+        ContainerTag changedSummary = div_changedSummary(diff);
 
         ContainerTag p_versions = p_versions(diff.getOldVersion(), diff.getNewVersion());
 
-        return renderHtml(ol_newEndpoint, ol_missingEndpoint, ol_changed, p_versions);
+        return renderHtml(ol_newEndpoint, ol_missingEndpoint, changedSummary, p_versions);
     }
 
     public String renderHtml(ContainerTag ol_new, ContainerTag ol_miss, ContainerTag ol_changed, ContainerTag p_versions) {
@@ -107,23 +109,123 @@ public class HtmlRender implements Render {
             del().withText(path)).with(span(null == desc ? "" : " " + desc));
     }
 
+    private ContainerTag div_changedSummary(SwaggerDiff diff) {
+        List<ChangedEndpoint> changedEndpoints = diff.getChangedEndpoints();
+        ContainerTag ol_changed = ol_changed(changedEndpoints);
+
+        ContainerTag container = div().withId("changed");
+
+        ChangedExtensionGroup topLevelExts = diff.getChangedTopLevelVendorExtensions();
+        ChangedExtensionGroup group = topLevelExts.getSubGroup("info");
+        if (group.vendorExtensionsAreDiff()) {
+            container.with(li().withClass("indent").withText("info")
+                .with(ul_changedVendorExtList(group, false, true)));
+        }
+        group = topLevelExts.getSubGroup("securityDefinitions");
+        if (group.vendorExtensionsAreDiff()) {
+            container.with(li().withClass("indent").withText("securityDefinitions"))
+                .with(ul_changedVendorExtMap(group, true));
+        }
+        group = topLevelExts.getSubGroup("tags");
+        if (group.vendorExtensionsAreDiff()) {
+            container.with(li().withClass("indent").withText("tags"))
+                .with(ul_changedVendorExtMap(group, true));
+        }
+
+        return container.with(ol_changed);
+    }
+
+    private ContainerTag ul_changedVendorExtMap(ChangedExtensionGroup group, boolean styled) {
+        ContainerTag ul = ul().withClasses("indent", iff(styled, "extension-container"));;
+        for (Entry<String, ChangedExtensionGroup> entry : group.getChangedSubGroups().entrySet()) {
+            if (entry.getValue().vendorExtensionsAreDiff()) {
+                ul.with(li().with(h3(entry.getKey()))
+                    .with(ul_changedVendorExtList(entry.getValue(), true, false)));
+            }
+        }
+        return ul;
+    }
+
+    private ContainerTag ul_changedVendorExtList(ChangedExtensionGroup group, boolean indented, boolean styled) {
+        ContainerTag ul = ul().withClasses(iff(indented, "indent"), iff(styled, "extension-container"));
+        for (ContainerTag li : changedVendorExts(group)) {
+            ul.with(li);
+        }
+        return ul;
+    }
+
+    private List<ContainerTag> changedVendorExts(ChangedExtensionGroup group) {
+        LinkedList<ContainerTag> list = new LinkedList<ContainerTag>();
+        for (String key : group.getIncreasedVendorExtensions().keySet()) {
+            list.add(li_addVendorExt(key));
+        }
+        for (String key : group.getMissingVendorExtensions().keySet()) {
+            list.add(li_missingVendorExt(key));
+        }
+        for (Entry<String, Pair<Object, Object>> entry : group.getChangedVendorExtensions().entrySet()) {
+            String key = entry.getKey();
+            Object left = entry.getValue().getLeft();
+            Object right = entry.getValue().getRight();
+            list.add(li_changedVendorExt(key, left, right));
+        }
+        return list;
+    }
+
+    private ContainerTag li_addVendorExt(String key) {
+        return li().withText("Add " + key);
+    }
+
+    private ContainerTag li_missingVendorExt(String key) {
+        return li().withClass("missing").withText("Delete ").with(del(key));
+    }
+
+    private ContainerTag li_changedVendorExt(String key, Object oldVal, Object newVal) {
+        return li().with(text(key + ": "))
+            .with(del(oldVal.toString()))
+            .with(text(" -> "))
+            .with(i().with(text(newVal.toString())));
+    }
+
     private ContainerTag ol_changed(List<ChangedEndpoint> changedEndpoints) {
-        if (null == changedEndpoints) return ol().withId("changed");
-        ContainerTag ol = ol().withId("changed");
+        if (null == changedEndpoints) return ol();
+        ContainerTag ol = ol();
+        ContainerTag ul_detail;
         for (ChangedEndpoint changedEndpoint : changedEndpoints) {
             String pathUrl = changedEndpoint.getPathUrl();
             Map<HttpMethod, ChangedOperation> changedOperations = changedEndpoint.getChangedOperations();
+
+            if (changedEndpoint.vendorExtensionsAreDiff()) {
+                ul_detail = ul();
+                if (changedEndpoint.vendorExtensionsAreDiff()) {
+                    ul_detail.with(li().with(ul_changedVendorExtList(changedEndpoint, false, false)));
+                }
+                ol.with(li().withText(pathUrl).with(ul_detail));
+            }
+
             for (Entry<HttpMethod, ChangedOperation> entry : changedOperations.entrySet()) {
                 String method = entry.getKey().toString();
                 ChangedOperation changedOperation = entry.getValue();
                 String desc = changedOperation.getSummary();
 
-                ContainerTag ul_detail = ul().withClass("detail");
+                ul_detail = ul().withClass("detail");
+                if (changedOperation.vendorExtensionsAreDiff()) {
+                    ul_detail.with(li().with(ul_changedVendorExtList(changedOperation, false, false)));
+                }
                 if (changedOperation.isDiffParam()) {
                     ul_detail.with(li().with(h3("Parameter")).with(ul_param(changedOperation)));
                 }
                 if (changedOperation.isDiffProp()) {
                     ul_detail.with(li().with(h3("Return Type")).with(ul_response(changedOperation)));
+                }
+                if (changedOperation.hasSubGroup("responses")) {
+                    ChangedExtensionGroup group = changedOperation.getSubGroup("responses");
+                    if (group.vendorExtensionsAreDiff()) {
+                        ContainerTag ul_response = ul().with(li().with(h3("Responses")));
+                        for (Entry<String, ChangedExtensionGroup> rEntry : group.getChangedSubGroups().entrySet()) {
+                            ul_response.with(li().withClass("indent").withText(rEntry.getKey()).with(ul_changedVendorExtList(rEntry.getValue(), true, false)));
+                        }
+                        ul_detail.with(ul_response);
+                    }
                 }
                 ol.with(li().with(span(method).withClass(method)).withText(pathUrl + " ").with(span(null == desc ? "" : desc))
                     .with(ul_detail));
@@ -172,7 +274,8 @@ public class HtmlRender implements Render {
         for (ChangedParameter param : changedParameters) {
             boolean changeRequired = param.isChangeRequired();
             boolean changeDescription = param.isChangeDescription();
-            if (changeRequired || changeDescription)
+            boolean changeVendorExtensions = param.vendorExtensionsAreDiff();
+            if (changeRequired || changeDescription || changeVendorExtensions)
                 ul.with(li_changedParam(param));
         }
         for (ChangedParameter param : changedParameters) {
@@ -198,16 +301,23 @@ public class HtmlRender implements Render {
     private ContainerTag li_changedParam(ChangedParameter changeParam) {
         boolean changeRequired = changeParam.isChangeRequired();
         boolean changeDescription = changeParam.isChangeDescription();
+        boolean changeVendorExtensions = changeParam.vendorExtensionsAreDiff();
         Parameter rightParam = changeParam.getRightParameter();
         Parameter leftParam = changeParam.getLeftParameter();
-        ContainerTag li = li().withText(rightParam.getName());
+        ContainerTag li = li().withText("Change " + rightParam.getName() + ":");
+        ContainerTag ul = ul().withClass("indent");
         if (changeRequired) {
-            li.withText(" change into " + (rightParam.getRequired() ? "required" : "not required"));
+            String newValue = (rightParam.getRequired() ? "required" : "not required");
+            String oldValue = (!rightParam.getRequired() ? "required" : "not required");
+            ul.with(li().with(del(oldValue)).withText(" -> " + newValue));
         }
         if (changeDescription) {
-            li.withText(" Notes ").with(del(leftParam.getDescription()).withClass("comment")).withText(" change into ").with(span(span(null == rightParam.getDescription() ? "" : rightParam.getDescription()).withClass("comment")));
+            ul.with(li().withText("Notes:").with(del(leftParam.getDescription()).withClass("comment")).withText(" -> ").with(span(span(null == rightParam.getDescription() ? "" : rightParam.getDescription()).withClass("comment"))));
         }
-        return li;
+        if (changeVendorExtensions) {
+            ul.with(li().with(ul_changedVendorExtList(changeParam, false, false)));
+        }
+        return li.with(ul);
     }
 
 }

--- a/src/main/java/com/deepoove/swagger/diff/output/MarkdownRender.java
+++ b/src/main/java/com/deepoove/swagger/diff/output/MarkdownRender.java
@@ -4,10 +4,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import org.apache.commons.lang3.tuple.Pair;
+
 import com.deepoove.swagger.diff.SwaggerDiff;
 import com.deepoove.swagger.diff.model.ChangedEndpoint;
 import com.deepoove.swagger.diff.model.ChangedOperation;
 import com.deepoove.swagger.diff.model.ChangedParameter;
+import com.deepoove.swagger.diff.model.ChangedVendorExtensionGroup;
 import com.deepoove.swagger.diff.model.Endpoint;
 import com.deepoove.swagger.diff.model.ElProperty;
 
@@ -24,32 +27,50 @@ public class MarkdownRender implements Render {
 	final String PRE_CODE = "    ";
 	final String PRE_LI = "    ";
 	final String LI = "* ";
-	final String HR = "---\n";
+	final String HR = "---\n\n";
+
+	String IT = "_";
+	String BD = "__";
+	String ST = "~~";
+	String RIGHT_ARROW = "&rarr;";
 
 	public MarkdownRender() {}
 
 	public String render(SwaggerDiff diff) {
-		List<Endpoint> newEndpoints = diff.getNewEndpoints();
+	  List<Endpoint> newEndpoints = diff.getNewEndpoints();
 		String ol_newEndpoint = ol_newEndpoint(newEndpoints);
 
 		List<Endpoint> missingEndpoints = diff.getMissingEndpoints();
 		String ol_missingEndpoint = ol_missingEndpoint(missingEndpoints);
 
+    String ol_topLevelVendorExt = ol_vendorExtSummary(diff.getChangedTopLevelVendorExtensions(), "");
+
 		List<ChangedEndpoint> changedEndpoints = diff.getChangedEndpoints();
 		String ol_changed = ol_changed(changedEndpoints);
 
-		return renderHtml(diff.getOldVersion(), diff.getNewVersion(), ol_newEndpoint, ol_missingEndpoint, ol_changed);
+		String ol_changeSummary = ol_topLevelVendorExt + ol_changed;
+
+		return renderMarkdown(diff.getOldVersion(), diff.getNewVersion(), ol_newEndpoint, ol_missingEndpoint, ol_changeSummary);
 	}
 
-	public String renderHtml(String oldVersion, String newVersion, String ol_new, String ol_miss,
-							 String ol_changed) {
+	public String renderBasic(SwaggerDiff diff) {
+		MarkdownRender renderer = new MarkdownRender();
+		renderer.IT = "";
+		renderer.BD = "";
+		renderer.ST = "";
+		renderer.RIGHT_ARROW = "->";
+		return renderer.render(diff);
+	}
+
+	private String renderMarkdown(String oldVersion, String newVersion, String ol_new, String ol_miss,
+                               String ol_changed) {
 		StringBuffer sb = new StringBuffer();
-		sb.append(H2).append("Version " + oldVersion + " to " + newVersion).append("\n").append(HR);
-		sb.append(H3).append("What's New").append("\n").append(HR)
+		sb.append(H2).append("Version " + oldVersion + " to " + newVersion + "\n").append(HR);
+		sb.append(H3).append("What's New\n").append(HR)
 				.append(ol_new).append("\n").append(H3)
-				.append("What's Deprecated").append("\n").append(HR)
+				.append("What's Deprecated\n").append(HR)
 				.append(ol_miss).append("\n").append(H3)
-				.append("What's Changed").append("\n").append(HR)
+				.append("What's Changed\n").append(HR)
 				.append(ol_changed);
 		return sb.toString();
 	}
@@ -83,11 +104,23 @@ public class MarkdownRender implements Render {
 
 	private String ol_changed(List<ChangedEndpoint> changedEndpoints) {
 		if (null == changedEndpoints) return "";
+
+		String detailPrefix = PRE_LI + PRE_LI;
+		String detailTitlePrefix = detailPrefix + LI + BD;
+		String operationPrefix = PRE_LI + LI + CODE;
+
 		StringBuffer sb = new StringBuffer();
 		for (ChangedEndpoint changedEndpoint : changedEndpoints) {
 			String pathUrl = changedEndpoint.getPathUrl();
 			Map<HttpMethod, ChangedOperation> changedOperations = changedEndpoint
 					.getChangedOperations();
+
+			sb.append(LI).append(pathUrl).append("\n");
+
+			if (changedEndpoint.vendorExtensionsAreDiff()) {
+				sb.append(ol_vendorExtSummary(changedEndpoint, "Vendor Extensions", PRE_LI));
+			}
+
 			for (Entry<HttpMethod, ChangedOperation> entry : changedOperations
 					.entrySet()) {
 				String method = entry.getKey().toString();
@@ -95,51 +128,120 @@ public class MarkdownRender implements Render {
 				String desc = changedOperation.getSummary();
 
 				StringBuffer ul_detail = new StringBuffer();
+				if (changedOperation.vendorExtensionsAreDiff()) {
+					ul_detail.append(ol_vendorExtSummary(changedOperation, detailPrefix));
+				}
 				if (changedOperation.isDiffParam()) {
-					ul_detail.append(PRE_LI).append("Parameter")
-							.append(ul_param(changedOperation));
+					ul_detail.append(detailTitlePrefix).append("Parameters")
+							.append(BD).append(ul_param(changedOperation));
 				}
 				if (changedOperation.isDiffProp()) {
-					ul_detail.append(PRE_LI).append("Return Type")
-							.append(ul_response(changedOperation));
+					ul_detail.append(detailTitlePrefix).append("Return Type")
+							.append(BD).append(ul_response(changedOperation));
 				}
-				sb.append(LI).append(CODE).append(method).append(CODE)
-						.append(" " + pathUrl).append(" " + desc + "  \n")
+				sb.append(operationPrefix).append(method).append(CODE)
+						.append(" - " + desc + "  \n")
 						.append(ul_detail);
 			}
 		}
 		return sb.toString();
 	}
 
+	private String ol_vendorExtSummary(ChangedVendorExtensionGroup container, String pre) {
+		return ol_vendorExtSummary(container, null, pre);
+	}
+
+	private String ol_vendorExtSummary(ChangedVendorExtensionGroup container, String title, String pre) {
+		if (!container.vendorExtensionsAreDiff()) return "";
+
+		Map<String, Object> increased = container.getIncreasedVendorExtensions();
+		Map<String, Object> missing = container.getMissingVendorExtensions();
+		Map<String, Pair<Object, Object>> changed = container.getChangedVendorExtensions();
+		Map<String, ChangedVendorExtensionGroup> subgroups = container.getChangedSubGroups();
+
+		String titlePrefix = pre + LI + BD;
+		String vendorExtPrefix = pre + LI;
+		String changedExtPre = pre + LI + CODE;
+		String changedExtMid = CODE + ": " + ST;
+		String changedExtArr = ST + " " + RIGHT_ARROW + " " + IT;
+		String incr = "";
+
+		StringBuffer sb = new StringBuffer();
+
+		if (title != null) {
+			sb.append(titlePrefix).append(title).append(BD + "\n");
+			vendorExtPrefix = PRE_LI + vendorExtPrefix;
+			changedExtPre = PRE_LI + changedExtPre;
+			incr = PRE_LI;
+		}
+
+		for (String vendorExtension : increased.keySet()) {
+			sb.append(vendorExtPrefix).append("Add ")
+          .append(CODE).append(vendorExtension).append(CODE + "\n");
+		}
+
+		for (String vendorExtension : missing.keySet()) {
+			sb.append(vendorExtPrefix).append("Remove ")
+          .append(CODE).append(vendorExtension).append(CODE + "\n");
+		}
+
+		for (String vendorExtension : changed.keySet()) {
+			Object left = changed.get(vendorExtension).getLeft();
+			Object right = changed.get(vendorExtension).getRight();
+			sb.append(changedExtPre).append(vendorExtension).append(changedExtMid)
+					.append(left.toString()).append(changedExtArr).append(right.toString())
+					.append(IT + "\n");
+		}
+
+		for (String groupName : subgroups.keySet()) {
+			sb.append(ol_vendorExtSummary(subgroups.get(groupName), groupName, pre + incr));
+		}
+
+		return sb.toString();
+	}
+
 	private String ul_response(ChangedOperation changedOperation) {
 		List<ElProperty> addProps = changedOperation.getAddProps();
 		List<ElProperty> delProps = changedOperation.getMissingProps();
-		StringBuffer sb = new StringBuffer("\n\n");
+		List<ElProperty> changedProps = changedOperation.getChangedProps();
+		StringBuffer sb = new StringBuffer("\n");
+
+		String prefix = PRE_LI + PRE_LI + PRE_CODE + LI;
 		for (ElProperty prop : addProps) {
-			sb.append(PRE_LI).append(PRE_CODE).append(li_addProp(prop) + "\n");
+			sb.append(prefix).append(li_addProp(prop) + "\n");
 		}
 		for (ElProperty prop : delProps) {
-			sb.append(PRE_LI).append(PRE_CODE)
-					.append(li_missingProp(prop) + "\n");
+			sb.append(prefix).append(li_missingProp(prop) + "\n");
+		}
+		for (ElProperty prop : changedProps) {
+			sb.append(prefix).append(ol_vendorExtSummary(prop, PRE_LI + PRE_LI + PRE_LI));
 		}
 		return sb.toString();
 	}
 
 	private String li_missingProp(ElProperty prop) {
 		Property property = prop.getProperty();
+		String prefix = "Delete " + CODE;
+		String desc = " //" + property.getDescription();
+		String postfix = CODE +
+				(null == property.getDescription() ? "" : desc);
+
 		StringBuffer sb = new StringBuffer("");
-		sb.append("Delete ").append(prop.getEl())
-				.append(null == property.getDescription() ? ""
-						: (" //" + property.getDescription()));
+		sb.append(prefix).append(prop.getEl())
+				.append(postfix);
 		return sb.toString();
 	}
 
 	private String li_addProp(ElProperty prop) {
 		Property property = prop.getProperty();
+		String prefix = "Add " + CODE;
+		String desc = " //" + property.getDescription();
+		String postfix = CODE +
+				(null == property.getDescription() ? "" : desc);
+
 		StringBuffer sb = new StringBuffer("");
-		sb.append("Add ").append(prop.getEl())
-				.append(null == property.getDescription() ? ""
-						: (" //" + property.getDescription()));
+		sb.append(prefix).append(prop.getEl())
+				.append(postfix);
 		return sb.toString();
 	}
 
@@ -148,67 +250,87 @@ public class MarkdownRender implements Render {
 		List<Parameter> delParameters = changedOperation.getMissingParameters();
 		List<ChangedParameter> changedParameters = changedOperation
 				.getChangedParameter();
-		StringBuffer sb = new StringBuffer("\n\n");
+
+		String prefix = PRE_LI + PRE_LI + PRE_CODE + LI;
+
+		StringBuffer sb = new StringBuffer("\n");
+
 		for (Parameter param : addParameters) {
-			sb.append(PRE_LI).append(PRE_CODE)
-					.append(li_addParam(param) + "\n");
+			sb.append(prefix).append(li_addParam(param) + "\n");
 		}
 		for (ChangedParameter param : changedParameters) {
 			List<ElProperty> increased = param.getIncreased();
 			for (ElProperty prop : increased) {
-				sb.append(PRE_LI).append(PRE_CODE)
-						.append(li_addProp(prop) + "\n");
+				sb.append(prefix).append(li_addProp(prop) + "\n");
 			}
 		}
 		for (ChangedParameter param : changedParameters) {
 			boolean changeRequired = param.isChangeRequired();
 			boolean changeDescription = param.isChangeDescription();
-			if (changeRequired || changeDescription) sb.append(PRE_LI)
-					.append(PRE_CODE).append(li_changedParam(param) + "\n");
+			boolean changeVendorExts = param.vendorExtensionsAreDiff();
+
+			if (changeRequired || changeDescription || changeVendorExts) {
+				sb.append(prefix).append(li_changedParam(param));
+			}
 		}
 		for (ChangedParameter param : changedParameters) {
 			List<ElProperty> missing = param.getMissing();
 			for (ElProperty prop : missing) {
-				sb.append(PRE_LI).append(PRE_CODE)
-						.append(li_missingProp(prop) + "\n");
+				sb.append(prefix).append(li_missingProp(prop) + "\n");
 			}
 		}
 		for (Parameter param : delParameters) {
-			sb.append(PRE_LI).append(PRE_CODE)
-					.append(li_missingParam(param) + "\n");
+			sb.append(prefix).append(li_missingParam(param) + "\n");
 		}
 		return sb.toString();
 	}
 
 	private String li_addParam(Parameter param) {
+		String prefix = "Add " + CODE;
+		String desc = " //" + param.getDescription();
+		String postfix = CODE +
+				(null == param.getDescription() ? "" : desc);
+
 		StringBuffer sb = new StringBuffer("");
-		sb.append("Add ").append(param.getName())
-				.append(null == param.getDescription() ? ""
-						: (" //" + param.getDescription()));
+		sb.append(prefix).append(param.getName())
+				.append(postfix);
 		return sb.toString();
 	}
 
 	private String li_missingParam(Parameter param) {
 		StringBuffer sb = new StringBuffer("");
-		sb.append("Delete ").append(param.getName())
-				.append(null == param.getDescription() ? ""
-						: (" //" + param.getDescription()));
+		String prefix = "Delete " + CODE;
+		String desc = " //" + param.getDescription();
+		String postfix = CODE +
+				(null == param.getDescription() ? "" : desc);
+		sb.append(prefix).append(param.getName())
+				.append(postfix);
 		return sb.toString();
 	}
 
 	private String li_changedParam(ChangedParameter changeParam) {
 		boolean changeRequired = changeParam.isChangeRequired();
 		boolean changeDescription = changeParam.isChangeDescription();
+		boolean vendorExtsChanged = changeParam.vendorExtensionsAreDiff();
 		Parameter rightParam = changeParam.getRightParameter();
 		Parameter leftParam = changeParam.getLeftParameter();
+
+		String vendorExtPrefix = PRE_LI + PRE_LI + PRE_LI + PRE_LI;
+
 		StringBuffer sb = new StringBuffer("");
-		sb.append(rightParam.getName());
+		sb.append(CODE + rightParam.getName() + CODE);
 		if (changeRequired) {
 			sb.append(" change into " + (rightParam.getRequired() ? "required" : "not required"));
 		}
 		if (changeDescription) {
 			sb.append(" Notes ").append(leftParam.getDescription()).append(" change into ")
 					.append(rightParam.getDescription());
+		}
+		if (vendorExtsChanged) {
+			sb.append(" vendor extensions Changed\n");
+			sb.append(ol_vendorExtSummary(changeParam, vendorExtPrefix));
+		} else {
+			sb.append("\n");
 		}
 		return sb.toString();
 	}

--- a/src/main/java/com/deepoove/swagger/diff/output/MarkdownRender.java
+++ b/src/main/java/com/deepoove/swagger/diff/output/MarkdownRender.java
@@ -195,6 +195,21 @@ public class MarkdownRender implements Render {
 		return sb.toString();
 	}
 
+	private String ul_paramChangedVendorExts(String paramName, ChangedExtensionGroup group, String pre) {
+		updateKeysWithParam(paramName, group.getIncreasedVendorExtensions());
+		updateKeysWithParam(paramName, group.getMissingVendorExtensions());
+		updateKeysWithParam(paramName, group.getChangedVendorExtensions());
+
+		return ul_changedVendorExts(group, pre);
+	}
+
+	private <V> void updateKeysWithParam(String prepend, Map<String, V> map) {
+		for (String key : map.keySet()) {
+			V value = map.remove(key);
+			map.put(prepend + "." + key, value);
+		}
+	}
+
 	private String li_addVendorExt(String key) {
 		return LI + "Add " + CODE + key + CODE + "\n";
 	}
@@ -280,7 +295,7 @@ public class MarkdownRender implements Render {
 			boolean changeVendorExts = param.vendorExtensionsAreDiff();
 
 			if (changeRequired || changeDescription || changeVendorExts) {
-				sb.append(prefix).append(li_changedParam(param));
+				sb.append(li_changedParam(param));
 			}
 		}
 		for (ChangedParameter param : changedParameters) {
@@ -325,10 +340,12 @@ public class MarkdownRender implements Render {
 		Parameter rightParam = changeParam.getRightParameter();
 		Parameter leftParam = changeParam.getLeftParameter();
 
-		String prefix = PRE_LI + PRE_LI + PRE_LI;
+		String prefix = PRE_LI + PRE_LI;
 
 		StringBuffer sb = new StringBuffer("");
-		sb.append(CODE + rightParam.getName() + CODE + ": " + "\n");
+		if (vendorExtsChanged) {
+			sb.append(ul_paramChangedVendorExts(rightParam.getName(), changeParam, prefix));
+		}
 		if (changeRequired) {
 			String oldValue = (rightParam.getRequired() ? "required" : "not required");
 			String newValue = (!rightParam.getRequired() ? "required" : "not required");
@@ -339,9 +356,6 @@ public class MarkdownRender implements Render {
 			sb.append(prefix).append(LI).append(" Notes ")
 					.append(leftParam.getDescription()).append(RIGHT_ARROW)
 					.append(rightParam.getDescription()).append("\n");
-		}
-		if (vendorExtsChanged) {
-			sb.append(ul_changedVendorExts(changeParam, prefix));
 		}
 		return sb.append("\n").toString();
 	}

--- a/src/main/java/com/deepoove/swagger/diff/output/MarkdownRender.java
+++ b/src/main/java/com/deepoove/swagger/diff/output/MarkdownRender.java
@@ -3,8 +3,6 @@ package com.deepoove.swagger.diff.output;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Queue;
-import java.util.concurrent.LinkedBlockingDeque;
 
 import org.apache.commons.lang3.tuple.Pair;
 
@@ -102,7 +100,7 @@ public class MarkdownRender implements Render {
 	private String ol_changeSummary(SwaggerDiff diff) {
 		StringBuffer sb = new StringBuffer();
 
-		ChangedExtensionGroup topLevelExts = diff.getChangedTopLevelVendorExtensions();
+		ChangedExtensionGroup topLevelExts = diff.getChangedVendorExtensions();
 		sb.append(ul_changedVendorExtsDeep(topLevelExts, ""));
 
 		List<ChangedEndpoint> changedEndpoints = diff.getChangedEndpoints();
@@ -161,8 +159,6 @@ public class MarkdownRender implements Render {
 		}
 		return sb.toString();
 	}
-
-	private String li_changedResponse(){ return null;}
 
 	private String ul_changedVendorExtsDeep(ChangedExtensionGroup group, String pre) {
 		StringBuffer sb = new StringBuffer();

--- a/src/main/java/com/deepoove/swagger/diff/output/MarkdownRender.java
+++ b/src/main/java/com/deepoove/swagger/diff/output/MarkdownRender.java
@@ -152,7 +152,6 @@ public class MarkdownRender implements Render {
 					if (group.vendorExtensionsAreDiff()) {
 						ul_detail.append(detailTitlePrefix + "Responses:" + BD + "\n");
 						ul_detail.append(ul_changedVendorExtsDeep(group, PRE_LI + PRE_LI));
-						System.out.println(group.getChangedSubGroups());
 					}
 				}
 				sb.append(operationPrefix).append(method).append(CODE + BD)

--- a/src/main/java/com/deepoove/swagger/diff/output/MarkdownRender.java
+++ b/src/main/java/com/deepoove/swagger/diff/output/MarkdownRender.java
@@ -10,7 +10,7 @@ import com.deepoove.swagger.diff.SwaggerDiff;
 import com.deepoove.swagger.diff.model.ChangedEndpoint;
 import com.deepoove.swagger.diff.model.ChangedOperation;
 import com.deepoove.swagger.diff.model.ChangedParameter;
-import com.deepoove.swagger.diff.model.ChangedVendorExtensionGroup;
+import com.deepoove.swagger.diff.model.ChangedExtensionGroup;
 import com.deepoove.swagger.diff.model.Endpoint;
 import com.deepoove.swagger.diff.model.ElProperty;
 
@@ -147,17 +147,17 @@ public class MarkdownRender implements Render {
 		return sb.toString();
 	}
 
-	private String ol_vendorExtSummary(ChangedVendorExtensionGroup container, String pre) {
+	private String ol_vendorExtSummary(ChangedExtensionGroup container, String pre) {
 		return ol_vendorExtSummary(container, null, pre);
 	}
 
-	private String ol_vendorExtSummary(ChangedVendorExtensionGroup container, String title, String pre) {
+	private String ol_vendorExtSummary(ChangedExtensionGroup container, String title, String pre) {
 		if (!container.vendorExtensionsAreDiff()) return "";
 
 		Map<String, Object> increased = container.getIncreasedVendorExtensions();
 		Map<String, Object> missing = container.getMissingVendorExtensions();
 		Map<String, Pair<Object, Object>> changed = container.getChangedVendorExtensions();
-		Map<String, ChangedVendorExtensionGroup> subgroups = container.getChangedSubGroups();
+		Map<String, ChangedExtensionGroup> subgroups = container.getChangedSubGroups();
 
 		String titlePrefix = pre + LI + BD;
 		String vendorExtPrefix = pre + LI;

--- a/src/main/java/com/deepoove/swagger/diff/output/MarkdownRender.java
+++ b/src/main/java/com/deepoove/swagger/diff/output/MarkdownRender.java
@@ -103,21 +103,7 @@ public class MarkdownRender implements Render {
 		StringBuffer sb = new StringBuffer();
 
 		ChangedExtensionGroup topLevelExts = diff.getChangedTopLevelVendorExtensions();
-		ChangedExtensionGroup group = topLevelExts.getSubGroup("info");
-		if (group.vendorExtensionsAreDiff()) {
-			sb.append(LI + "info\n");
-			sb.append(ul_changedVendorExts(group, PRE_LI));
-		}
-		group = topLevelExts.getSubGroup("securityDefinitions");
-		if (group.vendorExtensionsAreDiff()) {
-			sb.append(LI + "securityDefinitions\n");
-			sb.append(ul_changedVendorExtsDeep(group, PRE_LI));
-		}
-		group = topLevelExts.getSubGroup("tags");
-		if (group.vendorExtensionsAreDiff()) {
-			sb.append(LI + "tags\n");
-			sb.append(ul_changedVendorExtsDeep(group, PRE_LI));
-		}
+		sb.append(ul_changedVendorExtsDeep(topLevelExts, ""));
 
 		List<ChangedEndpoint> changedEndpoints = diff.getChangedEndpoints();
 		String ol_changed = ol_changed(changedEndpoints);
@@ -180,7 +166,7 @@ public class MarkdownRender implements Render {
 			String key = entry.getKey();
 			ChangedExtensionGroup subgroup = entry.getValue();
 			if (subgroup.vendorExtensionsAreDiff()) {
-				sb.append(pre + LI + key + "\n");
+				sb.append(pre + LI + IT + key + IT + "\n");
 				sb.append(ul_changedVendorExtsDeep(subgroup, pre + PRE_LI));
 			}
 		}

--- a/src/main/resources/demo.css
+++ b/src/main/resources/demo.css
@@ -137,10 +137,19 @@ ol>li {
 	margin: 24px;
 }
 
-ol>li>ul {
+ol>li>ul, .extension-container {
 	background-color: #504949;
 	color: #fff;
 	padding: 8px 16px;
+}
+
+.extension-container {
+  margin-top: 0px;
+}
+
+.indent {
+  margin-left: 24px;
+  margin-right: 24px;
 }
 
 ul.change>li {

--- a/src/test/java/com/deepoove/swagger/test/SwaggerDiffTest.java
+++ b/src/test/java/com/deepoove/swagger/test/SwaggerDiffTest.java
@@ -11,7 +11,7 @@ import org.junit.Test;
 import com.deepoove.swagger.diff.SwaggerDiff;
 import com.deepoove.swagger.diff.model.ChangedEndpoint;
 import com.deepoove.swagger.diff.model.ChangedOperation;
-import com.deepoove.swagger.diff.model.ChangedVendorExtensionGroup;
+import com.deepoove.swagger.diff.model.ChangedExtensionGroup;
 import com.deepoove.swagger.diff.model.Endpoint;
 import com.deepoove.swagger.diff.output.HtmlRender;
 import com.deepoove.swagger.diff.output.MarkdownRender;
@@ -83,11 +83,29 @@ public class SwaggerDiffTest {
 
 	}
 
+	private void assertVendorExtensionsAreDiff(ChangedExtensionGroup vendorExtensions) {
+		Assert.assertTrue(vendorExtensions.vendorExtensionsAreDiff());
+	}
+	
 	@Test
-	public void testDiffVendorExtension() {
+	public void testDiff() {
 		SwaggerDiff diff = SwaggerDiff.compareV2(SWAGGER_V2_DOC1, SWAGGER_V2_DOC2);
+		List<ChangedEndpoint> changedEndPoints = diff.getChangedEndpoints();
+		String html = new HtmlRender("Changelog",
+				"src/main/resources/demo.css")
+				.render(diff);
+		
+		try {
+			FileWriter fw = new FileWriter(
+					"testDiff.html");
+			fw.write(html);
+			fw.close();
+			
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
 
-		ChangedVendorExtensionGroup tlVendorExts = diff.getChangedTopLevelVendorExtensions();
+		ChangedExtensionGroup tlVendorExts = diff.getChangedTopLevelVendorExtensions();
 		assertVendorExtensionsAreDiff(tlVendorExts);
 		for (String key : tlVendorExts.getChangedSubGroups().keySet()) {
 			assertVendorExtensionsAreDiff(tlVendorExts.getChangedSubGroups().get(key));
@@ -101,29 +119,6 @@ public class SwaggerDiffTest {
 				ChangedOperation changedOperation = changedEndpoint.getChangedOperations().get(HttpMethod.POST);
 				assertVendorExtensionsAreDiff(changedOperation);
 			}
-		}
-	}
-
-	private void assertVendorExtensionsAreDiff(ChangedVendorExtensionGroup vendorExtensions) {
-		Assert.assertTrue(vendorExtensions.vendorExtensionsAreDiff());
-	}
-	
-	@Test
-	public void testDiff() {
-		SwaggerDiff diff = SwaggerDiff.compareV2(SWAGGER_V2_DOC1, SWAGGER_V2_DOC2);
-		List<ChangedEndpoint> changedEndPoints = diff.getChangedEndpoints();
-		String html = new HtmlRender("Changelog",
-				"http://deepoove.com/swagger-diff/stylesheets/demo.css")
-				.render(diff);
-		
-		try {
-			FileWriter fw = new FileWriter(
-					"testDiff.html");
-			fw.write(html);
-			fw.close();
-			
-		} catch (IOException e) {
-			e.printStackTrace();
 		}
 //		Assert.assertFalse(changedEndPoints.isEmpty());
 	}

--- a/src/test/java/com/deepoove/swagger/test/SwaggerDiffTest.java
+++ b/src/test/java/com/deepoove/swagger/test/SwaggerDiffTest.java
@@ -29,13 +29,13 @@ public class SwaggerDiffTest {
 
 	@Test
 	public void testEqual() {
-		SwaggerDiff diff = SwaggerDiff.compareV2(SWAGGER_V2_DOC2, SWAGGER_V2_DOC2);
+		SwaggerDiff diff = SwaggerDiff.compareV2(SWAGGER_V2_DOC2, SWAGGER_V2_DOC2, true);
 		assertEqual(diff);
 	}
 
 	@Test
 	public void testNewApi() {
-		SwaggerDiff diff = SwaggerDiff.compareV2(SWAGGER_V2_EMPTY_DOC, SWAGGER_V2_DOC2);
+		SwaggerDiff diff = SwaggerDiff.compareV2(SWAGGER_V2_EMPTY_DOC, SWAGGER_V2_DOC2, true);
 		List<Endpoint> newEndpoints = diff.getNewEndpoints();
 		List<Endpoint> missingEndpoints = diff.getMissingEndpoints();
 		List<ChangedEndpoint> changedEndPoints = diff.getChangedEndpoints();
@@ -60,7 +60,7 @@ public class SwaggerDiffTest {
 
 	@Test
 	public void testDeprecatedApi() {
-		SwaggerDiff diff = SwaggerDiff.compareV2(SWAGGER_V2_DOC1, SWAGGER_V2_EMPTY_DOC);
+		SwaggerDiff diff = SwaggerDiff.compareV2(SWAGGER_V2_DOC1, SWAGGER_V2_EMPTY_DOC, true);
 		List<Endpoint> newEndpoints = diff.getNewEndpoints();
 		List<Endpoint> missingEndpoints = diff.getMissingEndpoints();
 		List<ChangedEndpoint> changedEndPoints = diff.getChangedEndpoints();
@@ -125,7 +125,7 @@ public class SwaggerDiffTest {
 	
 	@Test
 	public void testDiffAndMarkdown() {
-		SwaggerDiff diff = SwaggerDiff.compareV2(SWAGGER_V2_DOC1, SWAGGER_V2_DOC2);
+		SwaggerDiff diff = SwaggerDiff.compareV2(SWAGGER_V2_DOC1, SWAGGER_V2_DOC2, true);
 		String render = new MarkdownRender().render(diff);
 		try {
 			FileWriter fw = new FileWriter(
@@ -144,7 +144,7 @@ public class SwaggerDiffTest {
 		try {
 			InputStream inputStream = getClass().getClassLoader().getResourceAsStream(SWAGGER_V2_DOC1);
 			JsonNode json = new ObjectMapper().readTree(inputStream);
-			SwaggerDiff diff = SwaggerDiff.compareV2(json, json);
+			SwaggerDiff diff = SwaggerDiff.compareV2(json, json, true);
 			assertEqual(diff);
 		} catch (IOException e) {
 			e.printStackTrace();

--- a/src/test/java/com/deepoove/swagger/test/SwaggerDiffTest.java
+++ b/src/test/java/com/deepoove/swagger/test/SwaggerDiffTest.java
@@ -89,7 +89,7 @@ public class SwaggerDiffTest {
 	
 	@Test
 	public void testDiff() {
-		SwaggerDiff diff = SwaggerDiff.compareV2(SWAGGER_V2_DOC1, SWAGGER_V2_DOC2);
+		SwaggerDiff diff = SwaggerDiff.compareV2(SWAGGER_V2_DOC1, SWAGGER_V2_DOC2, true);
 		List<ChangedEndpoint> changedEndPoints = diff.getChangedEndpoints();
 		String html = new HtmlRender("Changelog",
 				"src/main/resources/demo.css")

--- a/src/test/java/com/deepoove/swagger/test/SwaggerDiffTest.java
+++ b/src/test/java/com/deepoove/swagger/test/SwaggerDiffTest.java
@@ -105,7 +105,7 @@ public class SwaggerDiffTest {
 			e.printStackTrace();
 		}
 
-		ChangedExtensionGroup tlVendorExts = diff.getChangedTopLevelVendorExtensions();
+		ChangedExtensionGroup tlVendorExts = diff.getChangedVendorExtensions();
 		assertVendorExtensionsAreDiff(tlVendorExts);
 		for (String key : tlVendorExts.getChangedSubGroups().keySet()) {
 			assertVendorExtensionsAreDiff(tlVendorExts.getChangedSubGroups().get(key));

--- a/src/test/resources/petstore_v2_1.json
+++ b/src/test/resources/petstore_v2_1.json
@@ -11,7 +11,9 @@
     "license": {
       "name": "Apache 2.0",
       "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
-    }
+    },
+    "x-remove-info-ext": "remove me!",
+    "x-change-info-ext": "change me!"
   },
   "host": "petstore.swagger.io",
   "basePath": "/v2",
@@ -22,7 +24,9 @@
       "externalDocs": {
         "description": "Find out more",
         "url": "http://swagger.io"
-      }
+      },
+      "x-remove-tags-ext": "remove me!",
+      "x-change-tags-ext": "change me!"
     },
     {
       "name": "store",
@@ -42,7 +46,11 @@
   ],
   "paths": {
     "/pet": {
+      "x-remove-path-ext": "remove me!",
+      "x-change-path-ext": "change me!",
       "post": {
+        "x-remove-method-ext": "remove me!",
+        "x-change-method-ext": "change me!",
         "tags": [
           "pet"
         ],
@@ -65,12 +73,15 @@
             "required": true,
             "schema": {
               "$ref": "#/definitions/Pet"
-            }
+            },
+            "x-remove-param-ext": "remove me!",
+            "x-change-param-ext": "change me!"
           }
         ],
         "responses": {
           "405": {
-            "description": "Invalid input"
+            "description": "Invalid input",
+            "x-remove-response-ext": "remove me!"
           }
         },
         "security": [
@@ -802,6 +813,8 @@
   },
   "securityDefinitions": {
     "petstore_auth": {
+      "x-remove-security-ext": "remove me!",
+      "x-change-security-ext": "change me!",
       "type": "oauth2",
       "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
       "flow": "implicit",

--- a/src/test/resources/petstore_v2_1.json
+++ b/src/test/resources/petstore_v2_1.json
@@ -81,7 +81,8 @@
         "responses": {
           "405": {
             "description": "Invalid input",
-            "x-remove-response-ext": "remove me!"
+            "x-remove-response-ext": "remove me!",
+            "x-change-response-ext": "change me!"
           }
         },
         "security": [

--- a/src/test/resources/petstore_v2_1.json
+++ b/src/test/resources/petstore_v2_1.json
@@ -1,5 +1,7 @@
 {
   "swagger": "2.0",
+  "x-remove-root-ext": "remove me!",
+  "x-change-root-ext": "change me!",
   "info": {
     "description": "This is a sample server Petstore server.  You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For this sample, you can use the api key `special-key` to test the authorization filters.",
     "version": "1.0.0",

--- a/src/test/resources/petstore_v2_2.json
+++ b/src/test/resources/petstore_v2_2.json
@@ -11,7 +11,9 @@
     "license": {
       "name": "Apache 2.0",
       "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
-    }
+    },
+    "x-create-info-ext": "i was created!",
+    "x-change-info-ext": "i was changed!"
   },
   "host": "petstore.swagger.io",
   "basePath": "/v2",
@@ -22,7 +24,9 @@
       "externalDocs": {
         "description": "Find out more",
         "url": "http://swagger.io"
-      }
+      },
+      "x-create-tags-ext": "i was created!",
+      "x-change-tags-ext": "i was changed!"
     },
     {
       "name": "store",
@@ -42,7 +46,11 @@
   ],
   "paths": {
     "/pet": {
+      "x-create-path-ext": "i was created!",
+      "x-change-path-ext": "i was changed!",
       "post": {
+        "x-create-method-ext": "i was created!",
+        "x-change-method-ext": "i was changed!",
         "tags": [
           "pet"
         ],
@@ -65,7 +73,9 @@
             "required": true,
             "schema": {
               "$ref": "#/definitions/Pet"
-            }
+            },
+            "x-create-param-ext": "i was created!",
+            "x-change-param-ext": "i was changed!"
           },
           {
             "name": "tags",
@@ -720,7 +730,8 @@
             "description": "successful operation",
             "schema": {
               "$ref": "#/definitions/User"
-            }
+            },
+            "x-create-response-ext": "i was created!"
           },
           "400": {
             "description": "Invalid username supplied"
@@ -801,6 +812,8 @@
   },
   "securityDefinitions": {
     "petstore_auth": {
+      "x-create-security-ext": "i was created!",
+      "x-change-security-ext": "i was changed!",
       "type": "oauth2",
       "authorizationUrl": "http://petstore.swagger.io/oauth/dialog",
       "flow": "implicit",

--- a/src/test/resources/petstore_v2_2.json
+++ b/src/test/resources/petstore_v2_2.json
@@ -1,5 +1,7 @@
 {
   "swagger": "2.0",
+  "x-create-root-ext": "i was created!",
+  "x-change-root-ext": "i was changed!",
   "info": {
     "description": "This is a sample server Petstore server.  You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For this sample, you can use the api key `special-key` to test the authorization filters.",
     "version": "1.0.2",

--- a/src/test/resources/petstore_v2_2.json
+++ b/src/test/resources/petstore_v2_2.json
@@ -91,7 +91,9 @@
         ],
         "responses": {
           "405": {
-            "description": "Invalid input"
+            "description": "Invalid input",
+            "x-create-response-ext": "i was created!",
+            "x-change-response-ext": "i was changed!"
           }
         },
         "security": [
@@ -730,8 +732,7 @@
             "description": "successful operation",
             "schema": {
               "$ref": "#/definitions/User"
-            },
-            "x-create-response-ext": "i was created!"
+            }
           },
           "400": {
             "description": "Invalid username supplied"


### PR DESCRIPTION
This PR adds [vendor extension](https://swagger.io/docs/specification/2-0/swagger-extensions/) support to swagger-diff. To enable the vendor extensions, you can use the same methods as normal (compareV1/compareV2), with a 3rd argument (boolean) that will enable vendor extensions if true. The original API still exists, so there shouldn't be any issues with backwards compatibility

Vendor extensions are shown in the rendered Markdown and HTML just like any other changed value, as can be seen below in the partial diff rendering (vendor extensions start with `x-`):

---

* Add `x-create-root-ext`
* Delete `x-remove-root-ext`
* `x-change-root-ext`: change me!->i was changed!
* info
    * Add `x-create-info-ext`
    * Delete `x-remove-info-ext`
    * `x-change-info-ext`: change me!->i was changed!
* securityDefinitions
    * petstore_auth
        * Add `x-create-security-ext`
        * Delete `x-remove-security-ext`
        * `x-change-security-ext`: change me!->i was changed!
* tags
    * pet
        * Add `x-create-tags-ext`
        * Delete `x-remove-tags-ext`
        * `x-change-tags-ext`: change me!->i was changed!
* /pet
    * Add `x-create-path-ext`
    * Delete `x-remove-path-ext`
    * `x-change-path-ext`: change me!->i was changed!
* `POST` /pet Add a new pet to the store  
    * Add `x-create-method-ext`
    * Delete `x-remove-method-ext`
    * `x-change-method-ext`: change me!->i was changed!
    * Parameters
        * Add `tags` //add new query param demo
        * Add `body.newFeild` //a feild demo by sayi
        * Add `body.category.newCatFeild`
        * Add `body.x-create-param-ext`
        * Delete `body.x-remove-param-ext`
        * `body.x-change-param-ext`: change me!->i was changed!
        * Delete `body.category.name`
    * Responses:
        * 405
            * Add `x-create-response-ext`
            * Delete `x-remove-response-ext`
            * `x-change-response-ext`: change me!->i was changed!

---